### PR TITLE
compat issue #29: handle old style arguments in objects

### DIFF
--- a/argh/assembling.py
+++ b/argh/assembling.py
@@ -147,7 +147,7 @@ def _fix_compat_issue29(function):
     # @expects_obj and issue a warning.
     spec = compat.getargspec(function)
 
-    if spec.args == ['args']:
+    if spec.args in [['arg'], ['args'], ['self', 'arg'], ['self', 'args']]:
         # this is it -- a classic old-style function, goddamnit.
         # no checking *args and **kwargs because they are unlikely to matter.
         import warnings

--- a/argh/decorators.py
+++ b/argh/decorators.py
@@ -12,6 +12,7 @@
 Command decorators
 ~~~~~~~~~~~~~~~~~~
 """
+from argh.assembling import _fix_compat_issue29
 from argh.constants import (ATTR_ALIASES, ATTR_ARGS, ATTR_NAME,
                             ATTR_WRAPPED_EXCEPTIONS,
                             ATTR_WRAPPED_EXCEPTIONS_PROCESSOR,
@@ -54,7 +55,11 @@ def alias(new_name):  # pragma: nocover
     import warnings
     warnings.warn('Decorator @alias() is deprecated. '
                   'Use @aliases() or @named() instead.', DeprecationWarning)
-    return named(new_name)
+    def wrapper(func):
+        setattr(func, ATTR_NAME, new_name)
+        _fix_compat_issue29(func)
+        return func
+    return wrapper
 
 
 def aliases(*names):
@@ -136,6 +141,7 @@ def arg(*args, **kwargs):
         # the outermost decorator inserts its value before the innermost's:
         declared_args.insert(0, dict(option_strings=args, **kwargs))
         setattr(func, ATTR_ARGS, declared_args)
+        _fix_compat_issue29(func)
         return func
     return wrapper
 

--- a/test/test_regressions.py
+++ b/test/test_regressions.py
@@ -74,6 +74,22 @@ def test_regression_issue27():
     assert run(p, 'parrot --dead').out == 'this parrot is no more\n'
 
 
+def test_regression_issue29():
+    class Tool(object):
+        def __init__(self):
+            self.p = DebugArghParser()
+            self.p.add_commands([self.test_command])
+
+        @argh.alias("test")
+        @argh.arg("a1")
+        @argh.arg("a2")
+        def test_command(self, args):
+            return "test"
+
+    tool = Tool()
+    assert run(tool.p, "test 123 456").out == "test\n"
+
+
 def test_regression_issue31():
     """ Issue #31: Argh fails with parameter action type 'count' if a default
     value is provided.


### PR DESCRIPTION
New attributes can't be assigned to instancemethods after they've been declared so add old style function detection to the 'alias' and 'arg' decorators.
