### PR TITLE
Display defaults in argument help messages (#64)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,9 @@ and generally made *Argh* better:
 :Tony Narlock:        Adaptation of README to GitHub
 :Oskari Saarenmaa:    Compatibility improvements
 :Denis Lisov:         Support for keyword-only arguments (Python 3)
+:Paul Jacobson:       Defaults in argument help message
+:nilfisque:           Defaults in argument help message
+:jdoppler:            Bug reports (based on StackOverflow)
 
 ...you? :-)
     Patches, ideas and any feedback is highly appreciated.

--- a/argh/assembling.py
+++ b/argh/assembling.py
@@ -22,7 +22,7 @@ from argh.compat import OrderedDict
 from argh.constants import (ATTR_ALIASES, ATTR_ARGS, ATTR_NAME,
                             ATTR_INFER_ARGS_FROM_SIGNATURE,
                             ATTR_EXPECTS_NAMESPACE_OBJECT,
-                            PARSER_FORMATTER)
+                            PARSER_FORMATTER, DEFAULT_ARGUMENT_TEMPLATE)
 from argh.utils import get_subparsers, get_arg_spec
 from argh.exceptions import AssemblingError
 
@@ -309,6 +309,8 @@ def set_default_command(parser, function):
 
     for draft in command_args:
         draft = draft.copy()
+        if 'help' not in draft:
+            draft.update(help=DEFAULT_ARGUMENT_TEMPLATE)
         dest_or_opt_strings = draft.pop('option_strings')
         if parser.add_help and '-h' in dest_or_opt_strings:
             dest_or_opt_strings = [x for x in dest_or_opt_strings if x != '-h']

--- a/argh/constants.py
+++ b/argh/constants.py
@@ -47,6 +47,12 @@ PARSER_FORMATTER = argparse.ArgumentDefaultsHelpFormatter
 """ Default formatter to be used in implicitly instantiated ArgumentParser.
 """
 
+DEFAULT_ARGUMENT_TEMPLATE = '%(default)s'
+""" Default template of argument help message (see issue #64).
+The template ``%(default)s`` is used by `argparse` to display the argument's
+default value.
+"""
+
 #-----------------------------------------------------------------------------
 #
 # deprecated

--- a/test/test_assembling.py
+++ b/test/test_assembling.py
@@ -65,7 +65,8 @@ def test_set_default_command():
 
     assert parser.add_argument.mock_calls == [
         mock.call('foo', nargs='+', choices=[1,2], help='me', type=int),
-        mock.call('-b', '--bar', default=False, action='store_true')
+        mock.call('-b', '--bar', default=False, action='store_true',
+                  help=argh.constants.DEFAULT_ARGUMENT_TEMPLATE)
     ]
     assert parser.set_defaults.mock_calls == [
         mock.call(function=func)
@@ -142,7 +143,8 @@ def test_set_default_command_varargs():
     argh.set_default_command(parser, func)
 
     assert parser.add_argument.mock_calls == [
-        mock.call('file_paths', nargs='*'),
+        mock.call('file_paths', nargs='*', 
+                  help=argh.constants.DEFAULT_ARGUMENT_TEMPLATE),
     ]
 
 
@@ -160,9 +162,9 @@ def test_set_default_command_kwargs():
     argh.set_default_command(parser, func)
 
     assert parser.add_argument.mock_calls == [
-        mock.call('x'),
-        mock.call('foo'),
-        mock.call('--bar'),
+        mock.call('x', help=argh.constants.DEFAULT_ARGUMENT_TEMPLATE),
+        mock.call('foo', help=argh.constants.DEFAULT_ARGUMENT_TEMPLATE),
+        mock.call('--bar', help=argh.constants.DEFAULT_ARGUMENT_TEMPLATE),
     ]
 
 
@@ -197,9 +199,12 @@ def test_kwonlyargs():
     p.add_argument = mock.MagicMock()
     p.set_default_command(argh.command(cmd))
     assert p.add_argument.mock_calls == [
-        mock.call('-f', '--foo', type=str, default='abcd'),
-        mock.call('-b', '--bar', required=True),
-        mock.call('args', nargs='*')
+        mock.call('-f', '--foo', type=str, default='abcd',
+                  help=argh.constants.DEFAULT_ARGUMENT_TEMPLATE),
+        mock.call('-b', '--bar', required=True,
+                  help=argh.constants.DEFAULT_ARGUMENT_TEMPLATE),
+        mock.call('args', nargs='*',
+                  help=argh.constants.DEFAULT_ARGUMENT_TEMPLATE)
     ]
 
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -127,16 +127,19 @@ def test_simple_function_kwargs():
     assert run(p, 'hello --bar 123') == R(out='bar: 123\nfoo: hello\n', err='')
 
 
+@pytest.mark.xfail
 def test_simple_function_multiple():
-    pass
+    raise NotImplementedError
 
 
+@pytest.mark.xfail
 def test_simple_function_nested():
-    pass
+    raise NotImplementedError
 
 
+@pytest.mark.xfail
 def test_class_method_as_command():
-    pass
+    raise NotImplementedError
 
 
 def test_all_specs_in_one():
@@ -726,3 +729,26 @@ def test_kwonlyargs():
     else:
         message = 'the following arguments are required: --bar'
     assert run(p, 'test --foo=do', exit=True) == message
+
+
+def test_default_arg_values_in_help():
+    "Argument defaults should appear in the help message implicitly"
+
+    @argh.arg('name', default='Basil')
+    @argh.arg('--task', default='hang the Moose')
+    @argh.arg('--note', help='why is it a remarkable animal?')
+    def remind(name, task=None, reason='there are creatures living in it',
+               note='it can speak English'):
+        return "Oh what is it now, can't you leave me in peace..."
+
+    p = DebugArghParser()
+    p.set_default_command(remind)
+
+    assert 'Basil' in p.format_help()
+    assert 'Moose' in p.format_help()
+    assert 'creatures' in p.format_help()
+
+    # explicit help message is not obscured by the implicit one...
+    assert 'remarkable animal' in p.format_help()
+    # ...but is still present
+    assert 'it can speak' in p.format_help()


### PR DESCRIPTION
The origins are here: https://stackoverflow.com/questions/23567393/python-s-argh-library-preserve-docstring-formatting-in-help-message

Thanks to:
- jdoppler @ GitHub: described the problem and possible solutions in the issue tracker.
- nilfisque @ StackOverflow: created the question at StackOverflow and summarized the
  solutions.
- @hpaulj (Paul Jacobson): provided the original solution.
- cblake (Chuck Blake): provided an alternative description and solution which
  encouraged a bit of further research.
