### PR TITLE
Use reqs-dev.txt to build the tox environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,7 @@ envlist=py26,py27,py32,py34,pypy
 
 [testenv]
 deps=
-    coverage
-    mock
-    pytest
-    pytest-cov
+    -rreqs-dev.txt
 commands=
     py.test []
 


### PR DESCRIPTION
At the moment tox is unusable because installing dependencies without
forcing a version leads to a conflict. Using the reqs-dev.txt file to
install the dependencies fixes the issue.