### PR TITLE
Fix bug with skip_unknown_args=True

### DIFF
--- a/argh/dispatching.py
+++ b/argh/dispatching.py
@@ -149,7 +149,7 @@ def dispatch(parser, argv=None, add_help_command=True,
             argv, namespace=namespace
         )
         # store unknown args on the namespace
-        namespace_obj.remainder = remainder
+        namespace_obj._remainder = remainder
     else:
         namespace_obj = parser.parse_args(argv, namespace=namespace)
 

--- a/argh/dispatching.py
+++ b/argh/dispatching.py
@@ -140,16 +140,18 @@ def dispatch(parser, argv=None, add_help_command=True,
             argv.pop(0)
             argv.append('--help')
 
-    if skip_unknown_args:
-        parse_args = parser.parse_known_args
-    else:
-        parse_args = parser.parse_args
-
     if not namespace:
         namespace = ArghNamespace()
 
     # this will raise SystemExit if parsing fails
-    namespace_obj = parse_args(argv, namespace=namespace)
+    if skip_unknown_args:
+        namespace_obj, remainder = parser.parse_known_args(
+            argv, namespace=namespace
+        )
+        # store unknown args on the namespace
+        namespace_obj.remainder = remainder
+    else:
+        namespace_obj = parser.parse_args(argv, namespace=namespace)
 
     function = _get_function_from_namespace_obj(namespace_obj)
 


### PR DESCRIPTION
I tried using `parser.dispatch(skip_unknown_args=True)` but it didn't seem to work

This appears to fix it. The problem is that `parser.parse_known_args()` returns a tuple `(namespace, remainder)` instead of just a namespace object like `parser.parse_args`. Once you pass this to `_get_function_from_namespace_obj` it gets confused.

I saw a unit test but I'm not sure why it passes.

Here's a quick example (that didn't work before the fix). Right now I'm storing the remaining unknown args on the namespace as `_remainder` (could call this something else too), so it's at least accessible (if we use `@expects_obj`)

``` python
import argh
parser = argh.ArghParser()

@argh.arg('a')
@argh.expects_obj
def foo(args):
    print 'foo args', args

parser.add_commands([foo, bar])
parser.dispatch(skip_unknown_args=True)
```

Great library btw!
