### PR TITLE
Specify coverage version for py32

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,10 @@ deps=
     {[testenv]deps}
     argparse        # not shipped with Python < 2.7
 
+[testenv:py32]
+deps=
+    coverage==3.7.1
+
 [testenv:tdd]
 # Special case for active development phase.
 basepython=python3.2

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,10 @@ deps=
 # Special case for active development phase.
 basepython=python3.2
 deps=
-    {[testenv]deps}
     pytest-xdist
+    mock
+    pytest
+    pytest-cov
+    coverage==3.7.1
 commands=
     py.test --exitfirst --looponfail []


### PR DESCRIPTION
Without specifying the coverage version in the tox.ini file, tox will attempt to use coverage version 4.0b2 for the py32 environment. That coverage version is incompatible with Python3.2 as the package contains the explicit unicode literal that was introduced in Python 3.3 (via [PEP0414](https://www.python.org/dev/peps/pep-0414/)).