### PR TITLE
Include the license file in packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,7 @@
+# Including license files.
+include COPYING
+include COPYING.LESSER
+
 # needed for `python setup.py test`
 include test/__init__.py
 include test/base.py


### PR DESCRIPTION
Adds the license files to `MANIFEST.in` for inclusion in `sdist`s and related packages.

cc @goanpeca