### PR TITLE
Declare Python 3.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - 2.7
   - 3.4
   - 3.5
+  - 3.6
   - 'pypy'    # omitting due to obscure early segfault on PyPy 2.2.0
 sudo: false
 install:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ the following versions of Python:
 * 3.1 (`argparse` library is required; **not** tested)
 * 3.4
 * 3.5
+* 3.6
 
 .. versionchanged:: 0.15
    Added support for Python 3.x, dropped support for Python ≤ 2.5.

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: User Interfaces',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,py35,pypy
+envlist=py27,py34,py35,py36,pypy
 
 [testenv]
 deps=
@@ -9,6 +9,6 @@ commands=
 
 [testenv:tdd]
 # Special case for active development phase.
-basepython=python3.5
+basepython=python3.6
 commands=
     py.test --exitfirst --looponfail []


### PR DESCRIPTION
Enable tests and add Trove classifiers for Python 3.6.