### PR TITLE
Fix bug with skip_unknown_args=True

### DIFF
--- a/argh/dispatching.py
+++ b/argh/dispatching.py
@@ -140,16 +140,16 @@ def dispatch(parser, argv=None, add_help_command=True,
             argv.pop(0)
             argv.append('--help')
 
-    if skip_unknown_args:
-        parse_args = parser.parse_known_args
-    else:
-        parse_args = parser.parse_args
-
     if not namespace:
         namespace = ArghNamespace()
 
     # this will raise SystemExit if parsing fails
-    namespace_obj = parse_args(argv, namespace=namespace)
+    if skip_unknown_args:
+        namespace_obj, unknown_args = parser.parse_known_args(argv, namespace=namespace)
+        # store unknown args on the namespace
+        namespace_obj._unknown_args = unknown_args
+    else:
+        namespace_obj = parser.parse_args(argv, namespace=namespace)
 
     function = _get_function_from_namespace_obj(namespace_obj)
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -790,4 +790,4 @@ def test_unknown_args():
     assert run(p, '--foo 1') == R(out='1\n', err='')
     assert run(p, '--bar 1', exit=True) == 'unrecognized arguments: --bar 1'
     assert run(p, '--bar 1', exit=False,
-               kwargs={'skip_unknown_args': True}) == R(out=usage, err='')
+               kwargs={'skip_unknown_args': True}) == R(out='1\n', err='')


### PR DESCRIPTION
Passing `skip_unknown_args=True` to the parser only ever showed the
usage message.

The problem is that `parser.parse_known_args()`
(`ArgumentParser.parse_known_args`) returns a tuple
`(namespace, remainder)` instead of just a namespace object like
`parser.parse_args`. Once you pass this to
`_get_function_from_namespace_obj` it gets confused.

The unit test was expecting to only ever show the usage message when
skipping unknown args.

The remaining unknown args are stored on the namespace as `_unkown_args`,
so it's at least accessible (if we use `@expects_obj`)

```python
import argh
parser = argh.ArghParser()

@argh.arg('a')
@argh.expects_obj
def foo(args):
    print 'foo args', args

parser.add_commands([foo, bar])
parser.dispatch(skip_unknown_args=True)
```

This uses and supersedes #86 