### PR TITLE
Use Python's build in unittest.mock

### DIFF
--- a/reqs-dev.txt
+++ b/reqs-dev.txt
@@ -1,4 +1,3 @@
-mock==1.0.1
 pytest>=2.3.7
 pytest-cov>=1.8.0
 pytest-xdist>=1.11

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     install_requires = install_requires,
 
     # testing
-    tests_require = ['pytest', 'mock', 'iocapture'],
+    tests_require = ['pytest', 'iocapture'],
     cmdclass = {'test': PyTest},
 
     # copyright

--- a/test/test_assembling.py
+++ b/test/test_assembling.py
@@ -4,7 +4,7 @@ Unit Tests For Assembling Phase
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 """
 import sys
-import mock
+import unittest.mock as mock
 import pytest
 
 import argh

--- a/test/test_dispatching.py
+++ b/test/test_dispatching.py
@@ -4,7 +4,7 @@ Dispatching tests
 ~~~~~~~~~~~~~~~~~
 """
 import argh
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import pytest
 
 from .base import make_IO

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -8,7 +8,7 @@ import re
 import argparse
 
 import iocapture
-import mock
+import unittest.mock as mock
 import pytest
 
 import argh

--- a/test/test_interaction.py
+++ b/test/test_interaction.py
@@ -4,7 +4,7 @@ Interaction Tests
 ~~~~~~~~~~~~~~~~~
 """
 import sys
-import mock
+import unittest.mock as mock
 
 import argh
 


### PR DESCRIPTION
Since Python 3.3 the unittest module supports mock and replaces python-mock which is now deprecated.