### PR TITLE
Fix broken tests under Python 3.9.7+

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', 'pypy-3.7']
+        python-version: ['3.7', '3.8', '3.9', 'pypy-3.7']
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -17,12 +17,6 @@ from argh.exceptions import AssemblingError
 from .base import DebugArghParser, get_usage_string, run, CmdResult as R
 
 
-@pytest.mark.xfail(reason='TODO')
-def test_guessing_integration():
-    "guessing is used in dispatching"
-    assert 0
-
-
 def test_set_default_command_integration():
     def cmd(foo=1):
         return foo

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -371,7 +371,7 @@ def test_invalid_choice():
     p = DebugArghParser()
     p.add_commands([cmd])
 
-    assert run(p, 'bar', exit=True).startswith('invalid choice')
+    assert 'invalid choice' in run(p, 'bar', exit=True)
 
     if sys.version_info < (3,3):
         # Python before 3.3 exits with a less informative error
@@ -385,7 +385,7 @@ def test_invalid_choice():
     p = DebugArghParser()
     p.add_commands([cmd], namespace='nest')
 
-    assert run(p, 'nest bar', exit=True).startswith('invalid choice')
+    assert 'invalid choice' in run(p, 'nest bar', exit=True)
 
     if sys.version_info < (3,3):
         # Python before 3.3 exits with a less informative error
@@ -505,7 +505,7 @@ def test_explicit_cmd_name():
 
     p = DebugArghParser()
     p.add_commands([orig_name])
-    assert run(p, 'orig-name', exit=True).startswith('invalid choice')
+    assert 'invalid choice' in run(p, 'orig-name', exit=True)
     assert run(p, 'new-name').out == 'ok\n'
 
 
@@ -779,7 +779,7 @@ def test_unknown_args():
     p = DebugArghParser()
     p.set_default_command(cmd)
 
-    usage = get_usage_string('[-f FOO]')
+    get_usage_string('[-f FOO]')
 
     assert run(p, '--foo 1') == R(out='1\n', err='')
     assert run(p, '--bar 1', exit=True) == 'unrecognized arguments: --bar 1'


### PR DESCRIPTION
RCA: messages being checked was changed in
https://github.com/python/cpython/commit/097801844c99ea3916bebe1cc761257ea7083d34

Thanks to @stanislavlevin for the report and fix suggestion.

Fixes #148