### PR TITLE
docs: add Read the Docs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,6 +15,12 @@ build:
 sphinx:
    configuration: docs/conf.py
 
+# NOTE: PDF generation was intentionally disabled due to failed builds.
+# Should you require enabling this, please make sure that it's tested.
+# Note that a PR build may only include HTML, so a successful RTD build on push
+# does not mean that PDF generation is working properly.
+# See PR #160 for details.
+#
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 # formats:
 #    - pdf

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,25 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+#python:
+#   install:
+#   - requirements: docs/requirements.txt


### PR DESCRIPTION
Motivation: the builds for PRs are successful but the latest/stable ones are failing. This needs to be stabilised.

As the RTD docs mention[1], "With builds from pull requests, only HTML formats are generated. Other formats are resource intensive and will be built after merging."

The least we can do to make sure that the up-to-date documentation is properly published is turn off PDF which is failing (possibly due to the badges in README.rst). Should anyone request building PDF, it can be re-enabled after testing and fixing.

[1] https://docs.readthedocs.io/en/stable/config-file/v2.html#formats