### PR TITLE
Exit failure on CommandError or other wrapped error

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,7 +9,7 @@ Backwards incompatible changes:
 
 - Wrapped exceptions now cause ``dispatching.dispatch()`` to raise ``SystemExit(1)``
   instead of returning without error. For most users, this means failed commands
-  will now exit with a failure status instead of a success.
+  will now exit with a failure status instead of a success. (#161)
 
 Enhancements:
 

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,14 @@
 Changelog
 ~~~~~~~~~
 
+Version 0.29.0
+--------------
+
+Backwards incompatible changes:
+
+- Wrapped exceptions now cause ``dispatching.dispatch()`` to raise ``SystemExit``
+  instead of returning without error.
+
 Version 0.28.0
 --------------
 

--- a/CHANGES
+++ b/CHANGES
@@ -7,8 +7,15 @@ Version 0.29.0
 
 Backwards incompatible changes:
 
-- Wrapped exceptions now cause ``dispatching.dispatch()`` to raise ``SystemExit``
-  instead of returning without error.
+- Wrapped exceptions now cause ``dispatching.dispatch()`` to raise ``SystemExit(1)``
+  instead of returning without error. For most users, this means failed commands
+  will now exit with a failure status instead of a success.
+
+Enhancements:
+
+- Can control exit status (see Backwards Incompatible Changes above) when raising
+  ``CommandError`` using the ``code`` keyword arg.
+
 
 Version 0.28.0
 --------------

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -423,14 +423,13 @@ know that something can be wrong, you'll probably handle it this way::
             item = items[key]
         except KeyError as error:
             print(e)    # hide the traceback
-            sys.exit()  # bail out (unsafe!)
+            sys.exit(1)  # bail out (unsafe!)
         else:
             ... do something ...
             print(item)
 
-This works, but the print-and-exit tasks are repetitive; moreover, there are
-cases when you don't want to raise `SystemExit` and just need to collect the
-output in a uniform way. Use :class:`~argh.exceptions.CommandError`::
+This works, but the print-and-exit tasks are repetitive.
+Instead, you can use :class:`~argh.exceptions.CommandError`::
 
     def show_item(key):
         try:
@@ -442,7 +441,8 @@ output in a uniform way. Use :class:`~argh.exceptions.CommandError`::
             return item
 
 `Argh` will wrap this exception and choose the right way to display its
-message (depending on how :func:`~argh.dispatching.dispatch` was called).
+message (depending on how :func:`~argh.dispatching.dispatch` was called),
+then exit with exit status 1 (indicating failure).
 
 Decorator :func:`~argh.decorators.wrap_errors` reduces the code even further::
 
@@ -460,6 +460,20 @@ specified.  It also allows plugging in a preprocessor for the caught errors::
         raise CommandError('some error')
 
 The command above will print `ERR: some error`.
+
+If you want to print and exit while still indicating the command completed successfully,
+you can pass an optional `code` argument to the :class:`~argh.exceptions.CommandError`::
+
+    def show_item(key):
+        try:
+            item = items[key]
+        except KeyError as error:
+            raise CommandError(error, code=0)  # bail out, but exit with status 0
+        else:
+            ... do something ...
+            return item
+
+You can also pass any other code in order to exit with a specific error status.
 
 Packaging
 ---------

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -461,8 +461,9 @@ specified.  It also allows plugging in a preprocessor for the caught errors::
 
 The command above will print `ERR: some error`.
 
-If you want to print and exit while still indicating the command completed successfully,
-you can pass an optional `code` argument to the :class:`~argh.exceptions.CommandError`::
+If you want to print and exit while still indicating the command completed
+successfully, you can pass an optional `code` argument to the
+:class:`~argh.exceptions.CommandError`::
 
     def show_item(key):
         try:

--- a/src/argh/decorators.py
+++ b/src/argh/decorators.py
@@ -156,14 +156,6 @@ def wrap_errors(errors=None, processor=None, *args):
             def my_command(...):
                 ...
 
-    .. warning::
-
-        Currently wrapping an exception in this way leads to your app's return
-        code being ``0``, i.e. success.  This is a known bug (issue118_) which
-        is due to be fixed.  Please make sure you don't rely on this behaviour.
-
-    .. _issue118: https://github.com/neithere/argh/issues/118
-
     """
 
     def wrapper(func):

--- a/src/argh/dispatching.py
+++ b/src/argh/dispatching.py
@@ -294,8 +294,12 @@ def _execute_command(function, namespace_obj, errors_file, pre_call=None):
         )
 
         errors_file.write(str(processor(e)))
-        errors_file.write("\n")
-        sys.exit()
+        errors_file.write('\n')
+
+        # Use code from CommandError if available, otherwise default to 1
+        code = e.code if isinstance(e, CommandError) and e.code is not None else 1
+
+        sys.exit(code)
 
 
 def dispatch_command(function, *args, **kwargs):

--- a/src/argh/dispatching.py
+++ b/src/argh/dispatching.py
@@ -107,7 +107,7 @@ def dispatch(
 
     :param errors_file:
 
-        Same as `output_file` but for ``sys.stderr``.
+        Same as `output_file` but for ``sys.stderr``, and `None` is not accepted.
 
     :param raw_output:
 
@@ -219,7 +219,7 @@ def _execute_command(function, namespace_obj, errors_file, pre_call=None):
     Yields the results line by line.
 
     If :class:`~argh.exceptions.CommandError` is raised, its message is
-    appended to the results (i.e. yielded by the generator as a string).
+    written to the error file.
     All other exceptions propagate unless marked as wrappable
     by :func:`wrap_errors`.
     """

--- a/src/argh/dispatching.py
+++ b/src/argh/dispatching.py
@@ -301,7 +301,7 @@ def _execute_command(function, namespace_obj, errors_file, pre_call=None):
         )
 
         errors_file.write(str(processor(e)))
-        errors_file.write('\n')
+        errors_file.write("\n")
 
         # Use code from CommandError if available, otherwise default to 1
         code = e.code if isinstance(e, CommandError) and e.code is not None else 1

--- a/src/argh/dispatching.py
+++ b/src/argh/dispatching.py
@@ -136,6 +136,9 @@ def dispatch(
     which is interpreted as an expected event so the traceback is hidden.
     You can also mark arbitrary exceptions as "wrappable" by using the
     :func:`~argh.decorators.wrap_errors` decorator.
+
+    Wrapped exceptions, or other "expected errors" like parse failures,
+    will cause a SystemExit to be raised.
     """
     if completion:
         autocomplete(parser)
@@ -177,6 +180,7 @@ def dispatch(
         # normally this is stdout; can be any file
         f = output_file
 
+    # this may raise user exceptions, or SystemExit for wrapped exceptions
     for line in lines:
         # print the line as soon as it is generated to ensure that it is
         # displayed to the user before anything else happens, e.g.
@@ -219,7 +223,7 @@ def _execute_command(function, namespace_obj, errors_file, pre_call=None):
     Yields the results line by line.
 
     If :class:`~argh.exceptions.CommandError` is raised, its message is
-    written to the error file.
+    written to the error file, and a SystemExit is raised.
     All other exceptions propagate unless marked as wrappable
     by :func:`wrap_errors`.
     """
@@ -291,6 +295,7 @@ def _execute_command(function, namespace_obj, errors_file, pre_call=None):
 
         errors_file.write(str(processor(e)))
         errors_file.write("\n")
+        sys.exit()
 
 
 def dispatch_command(function, *args, **kwargs):

--- a/src/argh/exceptions.py
+++ b/src/argh/exceptions.py
@@ -31,7 +31,8 @@ class DispatchingError(Exception):
 class CommandError(Exception):
     """
     Intended to be raised from within a command.  The dispatcher wraps this
-    exception by default and prints its message without traceback.
+    exception by default and prints its message without traceback, then exits
+    with exit code 1.
 
     Useful for print-and-exit tasks when you expect a failure and don't want
     to startle the ordinary user by the cryptic output.
@@ -43,7 +44,7 @@ class CommandError(Exception):
                 ...
             except KeyError as e:
                 print(u'Could not fetch item: {0}'.format(e))
-                return
+                sys.exit(1)
 
     It is exactly the same as::
 
@@ -52,6 +53,9 @@ class CommandError(Exception):
                 ...
             except KeyError as e:
                 raise CommandError(u'Could not fetch item: {0}'.format(e))
+
+    To customize the exit status, pass an integer (as per sys.exit()) to the
+    ``code`` keyword arg.
 
     This exception can be safely used in both print-style and yield-style
     commands (see :doc:`tutorial`).
@@ -65,3 +69,7 @@ class CommandError(Exception):
     .. _issue118: https://github.com/neithere/argh/issues/118
 
     """
+
+    def __init__(self, *args, code=None):
+        self.code = code
+        super(CommandError, self).__init__(*args)

--- a/src/argh/exceptions.py
+++ b/src/argh/exceptions.py
@@ -53,20 +53,11 @@ class CommandError(Exception):
             except KeyError as e:
                 raise CommandError(u'Could not fetch item: {0}'.format(e))
 
-    To customize the exit status, pass an integer (as per sys.exit()) to the
-    ``code`` keyword arg.
+    To customize the exit status, pass an integer (as per ``sys.exit()``) to
+    the ``code`` keyword arg.
 
     This exception can be safely used in both print-style and yield-style
     commands (see :doc:`tutorial`).
-
-    .. warning::
-
-        Currently raising this exception leads to your app's return code being
-        ``0``, i.e. success.  This is a known bug (issue118_) which is due to
-        be fixed.  Please make sure you don't rely on this behaviour.
-
-    .. _issue118: https://github.com/neithere/argh/issues/118
-
     """
 
     def __init__(self, *args, code=None):

--- a/tests/base.py
+++ b/tests/base.py
@@ -9,9 +9,10 @@ from collections import namedtuple
 
 from argh import ArghParser
 
-_CmdResult = namedtuple("CmdResult", ("out", "err", "exit"))
+
 # hacky constructor for default exit value
 def CmdResult(out, err, exit=None):
+    _CmdResult = namedtuple("CmdResult", ("out", "err", "exit"))
     return _CmdResult(out, err, exit)
 
 
@@ -42,7 +43,7 @@ def call_cmd(parser, command_string, **kwargs):
         result = parser.dispatch(args, **kwargs)
     except SystemExit as e:
         result = None
-        exit = e.code or 0 # e.code may be None
+        exit = e.code or 0  # e.code may be None
     else:
         exit = None
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -27,7 +27,7 @@ def test_set_default_command_integration():
 
     assert run(p, "") == R(out="1\n", err="")
     assert run(p, "--foo 2") == R(out="2\n", err="")
-    assert run(p, "--help", exit=True) is None
+    assert run(p, "--help", exit=True) == 0
 
 
 def test_set_default_command_integration_merging():
@@ -440,7 +440,7 @@ def test_bare_namespace():
     # without arguments
 
     # returns a help message and doesn't exit
-    assert "usage:" in run(p, "greet", exit=True).out
+    assert "usage:" in run(p, "greet").out
 
     # with an argument
 
@@ -502,13 +502,13 @@ def test_help_alias():
 
     # assert the commands don't fail
 
-    assert run(p, "--help", exit=True) is None
-    assert run(p, "greet --help", exit=True) is None
-    assert run(p, "greet hello --help", exit=True) is None
+    assert run(p, "--help", exit=True) == 0
+    assert run(p, "greet --help", exit=True) == 0
+    assert run(p, "greet hello --help", exit=True) == 0
 
-    assert run(p, "help", exit=True) is None
-    assert run(p, "help greet", exit=True) is None
-    assert run(p, "help greet hello", exit=True) is None
+    assert run(p, "help", exit=True) == 0
+    assert run(p, "help greet", exit=True) == 0
+    assert run(p, "help greet hello", exit=True) == 0
 
 
 def test_arg_order():
@@ -741,7 +741,7 @@ def test_prog():
     usage = get_usage_string()
 
     with iocapture.capture() as captured:
-        assert run(p, "-h", exit=True) is None
+        assert run(p, "-h", exit=True) == 0
         assert captured.stdout.startswith(usage)
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -564,7 +564,9 @@ def test_command_error():
     p = DebugArghParser()
     p.add_commands([whiner_plain, whiner_iterable])
 
-    assert run(p, "whiner-plain") == R(out="", err="CommandError: I feel depressed.\n", exit=1)
+    assert run(p, "whiner-plain") == R(
+        out="", err="CommandError: I feel depressed.\n", exit=1
+    )
     assert run(p, "whiner-plain --code=127") == R(
         out="", err="CommandError: I feel depressed.\n", exit=127
     )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -292,7 +292,7 @@ class TestErrorWrapping:
         p.set_default_command(wrapped_parrot)
 
         assert run(p, "") == R("beautiful plumage\n", "")
-        assert run(p, "--dead") == R("", "ValueError: this parrot is no more\n")
+        assert run(p, "--dead") == R("", "ValueError: this parrot is no more\n", exit=1)
 
     def test_processor(self):
         parrot = self._get_parrot()
@@ -306,7 +306,7 @@ class TestErrorWrapping:
         p = argh.ArghParser()
         p.set_default_command(processed_parrot)
 
-        assert run(p, "--dead") == R("", "ERR: this parrot is no more!\n")
+        assert run(p, "--dead") == R("", "ERR: this parrot is no more!\n", exit=1)
 
     def test_stderr_vs_stdout(self):
         @argh.wrap_errors([KeyError])
@@ -318,7 +318,7 @@ class TestErrorWrapping:
         p.set_default_command(func)
 
         assert run(p, "a") == R(out="1\n", err="")
-        assert run(p, "b") == R(out="", err="KeyError: 'b'\n")
+        assert run(p, "b") == R(out="", err="KeyError: 'b'\n", exit=1)
 
 
 def test_argv():
@@ -549,8 +549,8 @@ def test_output_file():
 
 
 def test_command_error():
-    def whiner_plain():
-        raise argh.CommandError("I feel depressed.")
+    def whiner_plain(code=1):
+        raise argh.CommandError("I feel depressed.", code=code)
 
     def whiner_iterable():
         yield "Hello..."
@@ -559,9 +559,12 @@ def test_command_error():
     p = DebugArghParser()
     p.add_commands([whiner_plain, whiner_iterable])
 
-    assert run(p, "whiner-plain") == R(out="", err="CommandError: I feel depressed.\n")
+    assert run(p, "whiner-plain") == R(out="", err="CommandError: I feel depressed.\n", exit=1)
+    assert run(p, "whiner-plain --code=127") == R(
+        out="", err="CommandError: I feel depressed.\n", exit=127
+    )
     assert run(p, "whiner-iterable") == R(
-        out="Hello...\n", err="CommandError: I feel depressed.\n"
+        out="Hello...\n", err="CommandError: I feel depressed.\n", exit=1
     )
 
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -47,7 +47,7 @@ def test_regression_issue12_help_flag():
     # help added → conflict → short name ignored
     p = DebugArghParser("PROG", add_help=True)
     p.set_default_command(ddos)
-    assert run(p, "-h 127.0.0.1", exit=True) is None
+    assert run(p, "-h 127.0.0.1", exit=True) == 0
 
 
 def test_regression_issue27():


### PR DESCRIPTION
Upstreams https://github.com/ekimekim/yaargh/pull/12
Fixes https://github.com/neithere/argh/issues/118

This is a breaking change.

The old behavior was to return successfully from `dispatch()` if a CommandError or wrapped error was caught, not explicitly to exit with status 0.

In the vast majority of cases, users are writing something like:
```python
if __name__ == '__main__':
    argh.dispatch_command(mycommand)
```
and so when `dispatch()` returns, the interpreter almost always exits afterwards due to execution completing.

In order to control the exit code, we had to change this behaviour to explicitly `sys.exit()` on error. This might break users who are doing something after dispatch returns, but it's worth noting that `dispatch()` could already raise SystemExit if parsing failed or `--help` was given (this happens inside argparse itself).

Of course, the other breaking aspect of this change is that commands that used to appear to succeed will now report failure, but the cases where this is undesired are greatly outnumbered by the cases where the current behaviour is a latent bug.

Finally, we include the option to customize the exit status via a new keyword arg `code` to `CommandError`. This shouldn't be able to collide with any existing usage, because previously all keyword args to `CommandError` were rejected.
The name `code` for the keyword arg matches the same arg in `SystemExit`.

#### Upstreaming notes

The cherry-pick onto the latest version of `argh` turned out to be pretty clean, though I had to merge the `CHANGES` manually. I also updated the tutorial docs which I failed to do in my original PR.