### PR TITLE
fix: assumed prog name in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "argh"
-version = "0.28.0"
+version = "0.28.1"
 description = "An unobtrusive argparse wrapper with natural syntax"
 readme = "README.rst"
 requires-python = ">=3.8"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -797,7 +797,7 @@ def test_add_commands_no_overrides():
     def second_func():
         pass
 
-    p = argh.ArghParser()
+    p = argh.ArghParser(prog="myapp")
     p.add_commands(
         [first_func, second_func],
     )
@@ -808,7 +808,7 @@ def test_add_commands_no_overrides():
             captured.stdout
             == unindent(
                 f"""
-            usage: pytest [-h] {{first-func,second-func}} ...
+            usage: myapp [-h] {{first-func,second-func}} ...
 
             positional arguments:
               {{first-func,second-func}}
@@ -827,7 +827,7 @@ def test_add_commands_no_overrides():
             captured.stdout
             == unindent(
                 f"""
-            usage: pytest first-func [-h] [-f FOO]
+            usage: myapp first-func [-h] [-f FOO]
 
             Owl stretching time
 
@@ -852,7 +852,7 @@ def test_add_commands_namespace_overrides():
     def second_func():
         pass
 
-    p = argh.ArghParser()
+    p = argh.ArghParser(prog="myapp")
     p.add_commands(
         [first_func, second_func],
         namespace="ns",
@@ -868,7 +868,7 @@ def test_add_commands_namespace_overrides():
             captured.stdout
             == unindent(
                 f"""
-            usage: pytest [-h] {{ns}} ...
+            usage: myapp [-h] {{ns}} ...
 
             positional arguments:
               {{ns}}
@@ -886,7 +886,7 @@ def test_add_commands_namespace_overrides():
             captured.stdout
             == unindent(
                 f"""
-            usage: pytest ns [-h] {{first-func,second-func}} ...
+            usage: myapp ns [-h] {{first-func,second-func}} ...
 
             {HELP_OPTIONS_LABEL}:
               -h, --help            show this help message and exit
@@ -908,7 +908,7 @@ def test_add_commands_namespace_overrides():
             captured.stdout
             == unindent(
                 f"""
-            usage: pytest ns first-func [-h] [-f FOO]
+            usage: myapp ns first-func [-h] [-f FOO]
 
             Owl stretching time
 
@@ -933,7 +933,7 @@ def test_add_commands_func_overrides():
     def second_func():
         pass
 
-    p = argh.ArghParser()
+    p = argh.ArghParser(prog="myapp")
     p.add_commands(
         [first_func, second_func],
         func_kwargs={
@@ -948,7 +948,7 @@ def test_add_commands_func_overrides():
             captured.stdout
             == unindent(
                 f"""
-            usage: pytest [-h] {{first-func,second-func}} ...
+            usage: myapp [-h] {{first-func,second-func}} ...
 
             positional arguments:
               {{first-func,second-func}}
@@ -967,7 +967,7 @@ def test_add_commands_func_overrides():
             captured.stdout
             == unindent(
                 f"""
-            usage: pytest first-func [-h] [-f FOO]
+            usage: myapp first-func [-h] [-f FOO]
 
             func description override
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py310
     py311
     pypy3
+    as-module
     lint
 skipdist = true
 isolated_build = true
@@ -16,7 +17,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
-    3.11: py311,lint
+    3.11: py311,lint,as-module
     pypy-3.9: pypy3
 
 [testenv]
@@ -26,6 +27,11 @@ commands =
     pytest --cov=argh --cov-report html --cov-fail-under 100 {posargs:tests}
 setenv =
     PYTHONPATH=src
+
+[testenv:as-module]
+description = run unit tests, ensure they don't depend on specific prog name
+commands =
+    python -m pytest {posargs:tests}
 
 [testenv:docs]
 description = build the HTML docs using sphinx-build


### PR DESCRIPTION
The tests are run both locally and in CI via tox.  This guarantees reproducible runs.  However, they may be ran differently in some other conditions, e.g. when building a rpm/deb/etc.  For instance, `python -m pytest` would result in a different prog name and break tests if it was hard-coded there.

This change both fixes the tests and adds a tox env that would check this case in the future.

Fixes #170