### PR TITLE
Avoid depending on iocapture by using pytest's built-in feature

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ completion = [
 test = [
   "tox >= 4.4",
   "pytest >= 7.2",
-  "iocapture >= 0.1.2",
   "pytest-cov >= 4.0",
 ]
 docs = [


### PR DESCRIPTION
We carry this patch in Debian to avoid needing to package iocapture
