### PR TITLE
Keyword-only arguments as options (closes #191)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,10 +27,20 @@ Backwards incompatible changes:
       pre_call_hook(ns)
       argh.run_endpoint_function(func, ns, ...)
 
-  - Kwonly arguments without default values used to be marked as required
-    options (``--foo FOO``), now they are treated as positionals (``foo``) when
-    the default (legacy) name mapping policy is used.  Please consider the new
-    policy for better treatment of kwonly.
+  - A new policy for mapping function arguments to CLI arguments is used by
+    default (see :class:`argh.assembling.NameMappingPolicy`).
+    In case you need to retain the CLI mapping but cannot modify the function
+    signature to use kwonly args for options, consider using this::
+
+        set_default_command(
+            func, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+        )
+
+  - The name mapping policy `BY_NAME_IF_HAS_DEFAULT` slightly deviates from the
+    old behaviour. Kwonly arguments without default values used to be marked as
+    required options (``--foo FOO``), now they are treated as positionals
+    (``foo``). Please consider the new default policy (`BY_NAME_IF_KWONLY`) for
+    a better treatment of kwonly.
 
 Deprecated:
 
@@ -56,13 +66,14 @@ Enhancements:
 
   Please note that the names may change in the upcoming versions.
 
-- Selectable name mapping policies have been introduced for function argument
+- Configurable name mapping policy has been introduced for function argument
   to CLI argument translation (#191 → #199):
 
+  - `BY_NAME_IF_KWONLY` (default and recommended).
   - `BY_NAME_IF_HAS_DEFAULT` (close to pre-v.0.30 behaviour);
-  - `BY_NAME_IF_KWONLY` (recommended).
 
-  Please check API docs on `NameMappingPolicy` for details.
+  Please check API docs on :class:`argh.assembling.NameMappingPolicy` for
+  details.
 
 Version 0.29.4
 --------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,11 @@ Backwards incompatible changes:
       pre_call_hook(ns)
       argh.run_endpoint_function(func, ns, ...)
 
+  - Kwonly arguments without default values used to be marked as required
+    options (``--foo FOO``), now they are treated as positionals (``foo``) when
+    the default (legacy) name mapping policy is used.  Please consider the new
+    policy for better treatment of kwonly.
+
 Deprecated:
 
 - The `@expects_obj` decorator.  Rationale: it used to support the old,
@@ -50,6 +55,14 @@ Enhancements:
   - `argh.run_endpoint_function(endpoint_function, namespace, ...)`
 
   Please note that the names may change in the upcoming versions.
+
+- Selectable name mapping policies have been introduced for function argument
+  to CLI argument translation (#191 → #199):
+
+  - `BY_NAME_IF_HAS_DEFAULT` (close to pre-v.0.30 behaviour);
+  - `BY_NAME_IF_KWONLY` (recommended).
+
+  Please check API docs on `NameMappingPolicy` for details.
 
 Version 0.29.4
 --------------

--- a/README.rst
+++ b/README.rst
@@ -145,7 +145,7 @@ A potentially modular application with more control over the process:
         "Returns given word as is."
         return text
 
-    def greet(name, greeting: str = "Hello") -> str:
+    def greet(name: str, greeting: str = "Hello") -> str:
         "Greets the user with given name. The greeting is customizable."
         return f"{greeting}, {name}!"
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,3 +39,5 @@ intersphinx_mapping = {
 }
 
 nitpicky = True
+
+autodoc_typehints = "both"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,6 +26,7 @@ Details
    tutorial
    reference
    cookbook
+   the_story
    similar
    projects
    subparsers

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -25,9 +25,6 @@ API Reference
 .. automodule:: argh.exceptions
    :members:
 
-.. automodule:: argh.io
-   :members:
-
 .. automodule:: argh.utils
    :members:
 

--- a/docs/source/similar.rst
+++ b/docs/source/similar.rst
@@ -25,7 +25,7 @@ supports Python3.  Not every "yes" in this table would count as pro.
 * opster_ and finaloption_ support nested commands but are based on the
   outdated `optparse` library and therefore reimplement some features available
   in `argparse`. They also introduce decorators that don't just decorate
-  functions but change their behaviour, which is bad practice.
+  functions but change their behaviour, which is a questionable practice.
 * simpleopt_ has an odd API and is rather a simple replacement for standard
   libraries than an extension.
 * opterator_ is based on the outdated `optparse` and does not support nested
@@ -36,11 +36,20 @@ supports Python3.  Not every "yes" in this table would count as pro.
   worth migrating but it is surely very flexible and easy to use.
 * baker_
 * plumbum_
-* docopt_
+* docopt_ takes an inverted approach: you write the usage docs, it generates a
+  parser.  Then you need to wire the parsing results into you code manually.
 * aaargh_
 * cliff_
 * cement_
 * autocommand_
+* click_ is a rather popular library, a bit younger than Argh.  The authors of
+  both libraries even gave lightning talks on a PyCon within a few minutes :)
+  Although I expected it to kill Argh because it comes with Flask, in fact
+  it takes an approach so different from Argh that they can coexist.
+  Like Opster, Click's decorator replaces the underlying function (a
+  questionable practice); it does not derive the CLI arguments from the
+  function signature but entirely relies on additional decorators, while Argh
+  strives for the opposite.
 
 .. _argdeclare: http://code.activestate.com/recipes/576935-argdeclare-declarative-interface-to-argparse/
 .. _argparse-cli: http://code.google.com/p/argparse-cli/
@@ -59,3 +68,4 @@ supports Python3.  Not every "yes" in this table would count as pro.
 .. _cliff: http://pypi.python.org/pypi/cliff
 .. _cement: http://builtoncement.com/2.0/
 .. _autocommand: https://pypi.python.org/pypi/autocommand/
+.. _click: https://click.palletsprojects.com

--- a/docs/source/the_story.rst
+++ b/docs/source/the_story.rst
@@ -67,9 +67,10 @@ Revival
 -------
 
 The author returned to his FOSS projects in early 2023.  To his surprise, Argh
-was all but dead and its niche as the "natural API" was not occupied by any
-other project.  It actually made sense to revive it.  So a deep modernisation
-and refactoring began.
+was not dead at all and its niche as the "natural API" was not occupied by any
+other project.  It actually made sense to revive it.
+
+A deep modernisation and refactoring began.
 
 A number of pending issues were resolved and the last version to support
 Python 2.x was released with a bunch of bugfixes.
@@ -109,10 +110,11 @@ A more complete example::
 
     argh.dispatch_command(load)
 
-The syntax is a subject to change but the essence is clear:
+The syntax is subject to change but the essence is clear:
 
 * as few surprises to the reader as possible;
-* the function is declared in the normal way, like any other function;
+* the function used as a CLI command is declared and callable in the normal
+  way, like any other function;
 * type hints are used instead of ``@arg("foo", type=int)``
 * additional metadata can be injected into type hints when necessary in a way
   that won't confuse type checkers (like in FastAPI_, requires Python 3.9+);

--- a/docs/source/the_story.rst
+++ b/docs/source/the_story.rst
@@ -1,0 +1,121 @@
+The Story of Argh
+~~~~~~~~~~~~~~~~~
+
+Early history
+-------------
+
+Argh was first drafted by Andy in the airport while waiting for his flight.
+The idea was to make a simplified wrapper for Argparse with support for nested
+commands.  We'll focus on the function arguments vs. CLI arguments here.
+
+This is what Argh began with (around 2010)::
+
+    @arg("path", description="path to the file to load")
+    @arg("--file-format", choices=["yaml", "json"], default="json")
+    @arg("--dry-run", default=False)
+    def load(args):
+        do_something(args.path, args.file_format, args.dry_run)
+
+    argh.dispatch_command(load)
+
+You don't have to remember the details of the underlying Argparse interface
+(especially for subparsers); you would still declare almost everything, but in
+one place, close to the function itself.
+
+"The Natural Way"
+-----------------
+
+In late 2012 the behaviour previously available via `@plain_signature`
+decorator became standard::
+
+
+    @arg("path", help="path to the file to load")
+    @arg("--file-format", choices=["yaml", "json"])
+    def load(path, file_format="json", dry_run=False):
+        do_something(path, file_format, dry_run)
+
+    argh.dispatch_command(load)
+
+This unleashed the killer feature of Argh: now you can write normal functions —
+not for argparse but general-purpose ones.  Argh would infer the basic CLI
+argument definitions straight from the function signature.  The types and some
+actions (e.g. `store_true`) would be inferred from defaults.  You would only need
+to use the `@arg` decorator to enhance the information with something that had
+no place in function signature of the Python 2.x era.
+
+There's still an little ugly thing about it: you have to mention the argument
+name twice, in function signature and the decorator.  Also the type cannot be
+inferred if there's no default value, so you'd have to use the decorator even
+for that.
+
+Hiatus
+------
+
+The primary author's new job required focus on other languages for a number of
+years and he had no energy to develop his FOSS projects, although he continued
+using Argh for his own purposes on a daily basis.
+
+A few forks were created by other developers but none survived.  (The forks,
+not developers.)
+
+By coincidence, around the beginning of this period a library called Click was
+shipped with Flask and it seemed obvious that it will become the new standard
+for simple CLI APIs and Argh wouldn't be needed. (Plot twist: it did become
+popular but its goals are too different from Argh's to replace it.)
+
+Revival
+-------
+
+The author returned to his FOSS projects in early 2023.  To his surprise, Argh
+was all but dead and its niche as the "natural API" was not occupied by any
+other project.  It actually made sense to revive it.  So a deep modernisation
+and refactoring began.
+
+A number of pending issues were resolved and the last version to support
+Python 2.x was released with a bunch of bugfixes.
+
+The next few releases have deprecated and removed a lot of outdated features
+and paved the way to a better Argh.  Some design decisions have been revised
+and the streamlined.  The work continues.
+
+Goodbye Decorators
+------------------
+
+As type hints became mature and widespread in Python code, the old approach
+with decorators seems to make less and less sense.  A lot more can be now
+inferred directly from the signature.  In fact, possibly everything.
+
+Here's what Argh is heading for (around 2024).
+
+A minimal example (note how there's literally nothing CLI-specific here)::
+
+    def load(path: str, *, file_format: str = "json", dry_run: bool = False) -> str:
+        return do_something(path, file_format, dry_run)
+
+    argh.dispatch_command(load)
+
+A more complete example::
+
+    from typing import Annotated
+    from argh import Choices, Help
+
+    def load(
+        path: Annotated[str, Help("path to the file to load")],
+        *,
+        file_format: Annotated[str, Choices(FORMAT_CHOICES))] = DEFAULT_FORMAT,
+        dry_run: bool = False
+    ) -> str:
+        return do_something(path, file_format, dry_run)
+
+    argh.dispatch_command(load)
+
+The syntax is a subject to change but the essence is clear:
+
+* as few surprises to the reader as possible;
+* the function is declared in the normal way, like any other function;
+* type hints are used instead of ``@arg("foo", type=int)``
+* additional metadata can be injected into type hints when necessary in a way
+  that won't confuse type checkers (like in FastAPI_, requires Python 3.9+);
+* non-kwonly become CLI positionals, kwonly become CLI options.
+
+.. _FastAPI: https://fastapi.tiangolo.com/python-types/#type-hints-with-metadata-annotations

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -83,7 +83,7 @@ knowing about `argh`::
 
 When executed as ``app.py my-command --help``, such application prints::
 
-    usage: app.py my-command [-h] [-b BETA] [-g] alpha [delta [delta ...]]
+    usage: app.py my-command [-h] [-b BETA] [-g] alpha [delta ...]
 
     positional arguments:
       alpha
@@ -122,6 +122,24 @@ Verbose, hardly readable, requires learning another API.
 
 Hey, that's a lot for such a simple case!  But then, that's why the API feels
 natural: `argh` does a lot of work for you.
+
+.. note::
+
+    The pattern described above is the "by name if has default" mapping policy.
+    It used to be *the* policy but starting with Argh v.0.30 there's a better
+    one, "by name if kwonly".  Although the older one will remain the default
+    policy for a while, it may be eventually dropped in favour of the new one.
+
+    Please check `~argh.assembling.NameMappingPolicy` for details.
+
+    Usage example::
+
+        def my_command(alpha, beta=1, *, gamma, delta=False, **kwargs):
+            ...
+
+        argh.dispatch_command(
+            my_command, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_KWONLY
+        )
 
 Well, there's nothing more elegant than a simple function.  But simplicity
 comes at a cost in terms of flexibility.  Fortunately, `argh` doesn't stay in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,3 +90,6 @@ include = [
   "tests/",
   "tox.ini",
 ]
+
+[tool.doc8]
+max-line-length = 95

--- a/src/argh/assembling.py
+++ b/src/argh/assembling.py
@@ -238,7 +238,7 @@ def guess_extra_parser_add_argument_spec_kwargs(
 def set_default_command(
     parser,
     function: Callable,
-    name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT,
+    name_mapping_policy: NameMappingPolicy = NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT,
 ) -> None:
     """
     Sets default command (i.e. a function) for given parser.
@@ -246,9 +246,16 @@ def set_default_command(
     If `parser.description` is empty and the function has a docstring,
     it is used as the description.
 
-    :param function: the function to use as the command.
-    :name_mapping_policy: the policy to use when mapping function arguments
-        onto CLI arguments.
+    :param function:
+
+        The function to use as the command.
+
+    :name_mapping_policy:
+
+        The policy to use when mapping function arguments onto CLI arguments.
+        See :class:`.NameMappingPolicy`.
+
+        .. versionadded:: 0.30
 
     .. note::
 
@@ -273,7 +280,6 @@ def set_default_command(
     )
 
     if declared_args and not inferred_args and not has_varkw:
-        # XXX breaking change, new behaviour
         raise AssemblingError(
             f"{function.__name__}: cannot extend argument declarations "
             "for an endpoint function that takes no arguments."
@@ -464,7 +470,9 @@ def add_commands(
 
     :param name_mapping_policy:
 
-        See :class:`~NameMappingPolicy`.
+        See :class:`argh.assembling.NameMappingPolicy`.
+
+        .. versionadded:: 0.30
 
     :param group_name:
 

--- a/src/argh/assembling.py
+++ b/src/argh/assembling.py
@@ -38,6 +38,7 @@ __all__ = [
     "set_default_command",
     "add_commands",
     "add_subcommands",
+    "NameMappingPolicy",
 ]
 
 

--- a/src/argh/assembling.py
+++ b/src/argh/assembling.py
@@ -15,10 +15,10 @@ Functions and classes to properly assemble your commands in a parser.
 """
 import inspect
 from argparse import OPTIONAL, ZERO_OR_MORE, ArgumentParser
-from collections import defaultdict, OrderedDict
+from collections import OrderedDict
 from dataclasses import asdict
 from enum import Enum
-from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
 
 from argh.completion import COMPLETION_ENABLED
 from argh.constants import (
@@ -84,13 +84,16 @@ class NameMappingPolicy(Enum):
 
     .. versionadded:: 0.30
     """
+
     BY_NAME_IF_HAS_DEFAULT = "specify CLI argument by name if it has a default value"
     BY_NAME_IF_KWONLY = "specify CLI argument by name if it comes from kwonly"
 
 
 def infer_argspecs_from_function(
     function: Callable,
-    name_mapping_policy: Optional[NameMappingPolicy] = NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+    name_mapping_policy: Optional[
+        NameMappingPolicy
+    ] = NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT,
 ) -> Iterator[ParserAddArgumentSpec]:
     if getattr(function, ATTR_EXPECTS_NAMESPACE_OBJECT, False):
         return
@@ -127,16 +130,17 @@ def infer_argspecs_from_function(
 
         return positionals, options
 
+    default_value: Any
     for arg_name in func_spec.args:
-        arg_call_kwargs: dict[str, Any] = {}
-        cli_arg_names_positional, cli_arg_names_options = _make_cli_arg_names_options(arg_name)
-        default_value: Any = default_by_arg_name.get(arg_name, NotDefined)
+        cli_arg_names_positional, cli_arg_names_options = _make_cli_arg_names_options(
+            arg_name
+        )
+        default_value = default_by_arg_name.get(arg_name, NotDefined)
 
         arg_spec = ParserAddArgumentSpec(
             func_arg_name=arg_name,
             cli_arg_names=cli_arg_names_positional,
             default_value=default_value,
-            other_add_parser_kwargs=arg_call_kwargs
         )
 
         if default_value != NotDefined:
@@ -148,10 +152,10 @@ def infer_argspecs_from_function(
         yield arg_spec
 
     for arg_name in func_spec.kwonlyargs:
-        arg_call_kwargs: dict[str, Any] = {}
-        cli_arg_names_positional, cli_arg_names_options = _make_cli_arg_names_options(arg_name)
+        cli_arg_names_positional, cli_arg_names_options = _make_cli_arg_names_options(
+            arg_name
+        )
 
-        default_value: Any
         if func_spec.kwonlydefaults and arg_name in func_spec.kwonlydefaults:
             default_value = func_spec.kwonlydefaults[arg_name]
         else:
@@ -161,7 +165,6 @@ def infer_argspecs_from_function(
             func_arg_name=arg_name,
             cli_arg_names=cli_arg_names_positional,
             default_value=default_value,
-            other_add_parser_kwargs=arg_call_kwargs
         )
 
         if name_mapping_policy == NameMappingPolicy.BY_NAME_IF_KWONLY:
@@ -178,7 +181,7 @@ def infer_argspecs_from_function(
         yield ParserAddArgumentSpec(
             func_arg_name=func_spec.varargs,
             cli_arg_names=[func_spec.varargs.replace("_", "-")],
-            nargs=ZERO_OR_MORE
+            nargs=ZERO_OR_MORE,
         )
 
 
@@ -231,8 +234,11 @@ def guess_extra_parser_add_argument_spec_kwargs(
     return guessed
 
 
-def set_default_command(parser, function: Callable,
-                        name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT) -> None:
+def set_default_command(
+    parser,
+    function: Callable,
+    name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT,
+) -> None:
     """
     Sets default command (i.e. a function) for given parser.
 
@@ -524,7 +530,9 @@ def add_commands(
 
         # create and set up the parser for this command
         command_parser = subparsers_action.add_parser(cmd_name, **func_parser_kwargs)
-        set_default_command(command_parser, func, name_mapping_policy=name_mapping_policy)
+        set_default_command(
+            command_parser, func, name_mapping_policy=name_mapping_policy
+        )
 
 
 def _extract_command_meta_from_func(func: Callable) -> Tuple[str, dict]:

--- a/src/argh/assembling.py
+++ b/src/argh/assembling.py
@@ -49,7 +49,7 @@ class NameMappingPolicy(Enum):
 
     * `BY_NAME_IF_HAS_DEFAULT` is very close to the the legacy approach
       (pre-v.0.30).  If a function argument has a default value, it becomes an
-      "option" (called by name, like `--foo`); otherwise it's treated as a
+      "option" (called by name, like ``--foo``); otherwise it's treated as a
       positional argument.
 
       Example::
@@ -62,15 +62,16 @@ class NameMappingPolicy(Enum):
 
       The difference between this policy and the behaviour of Argh before
       v.0.30 is in the treatment of kwonly arguments without default values:
-      they use to become `--foo FOO` (required) but for the sake of simplicity
-      they are treated as positionals.  If you are already using kwonly args,
-      please consider the better suited policy `BY_NAME_IF_KWONLY` instead.
+      they used to become ``--foo FOO`` (required) but for the sake of
+      simplicity they are treated as positionals.  If you are already using
+      kwonly args, please consider the better suited policy `BY_NAME_IF_KWONLY`
+      instead.
 
     * `BY_NAME_IF_KWONLY` is the newer approach.  It enables finer control over
       positional vs named and required vs optional.  "Normal" arguments become
       positionals, "kwonly" become "options", regardless of the presence of
       default values.  A positional with a default value becomes optional but
-      still positional (`nargs=OPTIONAL`).  A kwonly argument without a default
+      still positional (``nargs=OPTIONAL``).  A kwonly argument without a default
       value becomes a required "option".
 
       Example::

--- a/src/argh/assembling.py
+++ b/src/argh/assembling.py
@@ -221,6 +221,7 @@ def guess_extra_parser_add_argument_spec_kwargs(
     # TODO: use typing to extract
     other_add_parser_kwargs = parser_add_argument_spec.other_add_parser_kwargs
     guessed: Dict[str, Any] = {}
+    is_positional = not parser_add_argument_spec.cli_arg_names[0].startswith("-")
 
     # Parser actions that accept argument 'type'
     TYPE_AWARE_ACTIONS = "store", "append"
@@ -229,8 +230,9 @@ def guess_extra_parser_add_argument_spec_kwargs(
     default_value = parser_add_argument_spec.default_value
     if default_value not in (None, NotDefined):
         if isinstance(default_value, bool):
-            if other_add_parser_kwargs.get("action") is None:
+            if not is_positional and other_add_parser_kwargs.get("action") is None:
                 # infer action from default value
+                # (not applicable to positionals: _StoreAction doesn't accept `nargs`)
                 guessed["action"] = "store_false" if default_value else "store_true"
         elif other_add_parser_kwargs.get("type") is None:
             # infer type from default value

--- a/src/argh/assembling.py
+++ b/src/argh/assembling.py
@@ -187,7 +187,6 @@ def infer_argspecs_from_function(
         )
 
 
-
 def guess_extra_parser_add_argument_spec_kwargs(
     parser_add_argument_spec: ParserAddArgumentSpec,
 ) -> Dict[str, Any]:

--- a/src/argh/dispatching.py
+++ b/src/argh/dispatching.py
@@ -193,7 +193,7 @@ def parse_and_resolve(
     skip_unknown_args: bool = False,
 ) -> Tuple[Optional[Callable], argparse.Namespace]:
     """
-    .. versionadded: 0.30
+    .. versionadded:: 0.30
 
     Parses CLI arguments and resolves the endpoint function.
     """
@@ -227,7 +227,7 @@ def run_endpoint_function(
     raw_output: bool = False,
 ) -> Optional[str]:
     """
-    .. versionadded: 0.30
+    .. versionadded:: 0.30
 
     Extracts arguments from the namespace object, calls the endpoint function
     and processes its output.
@@ -327,16 +327,17 @@ def _execute_command(
 
             # *args
             if spec.varargs:
-                positional += getattr(namespace_obj, spec.varargs)
+                positional += all_input[spec.varargs]
 
             # **kwargs
             varkw = getattr(spec, "varkw", getattr(spec, "keywords", []))
             if varkw:
                 not_kwargs = [DEST_FUNCTION] + spec.args + [spec.varargs] + kwonly
                 for k in vars(namespace_obj):
-                    if k.startswith("_") or k in not_kwargs:
+                    normalized_k = _flat_key(k)
+                    if k.startswith("_") or normalized_k in not_kwargs:
                         continue
-                    keywords[k] = getattr(namespace_obj, k)
+                    keywords[normalized_k] = getattr(namespace_obj, k)
 
             result = function(*positional, **keywords)
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -11,9 +11,9 @@ from argh import ArghParser
 
 
 # hacky constructor for default exit value
-def CmdResult(out, err, exit=None):
-    _CmdResult = namedtuple("CmdResult", ("out", "err", "exit"))
-    return _CmdResult(out, err, exit)
+def CmdResult(out, err, exit_code=None):
+    _CmdResult = namedtuple("CmdResult", ("out", "err", "exit_code"))
+    return _CmdResult(out, err, exit_code)
 
 
 class DebugArghParser(ArghParser):
@@ -43,16 +43,16 @@ def call_cmd(parser, command_string, **kwargs):
         result = parser.dispatch(args, **kwargs)
     except SystemExit as e:
         result = None
-        exit = e.code or 0  # e.code may be None
+        exit_code = e.code or 0  # e.code may be None
     else:
-        exit = None
+        exit_code = None
 
     if kwargs.get("output_file") is None:
-        return CmdResult(out=result, err=io_err.read(), exit=exit)
-    else:
-        io_out.seek(0)
-        io_err.seek(0)
-        return CmdResult(out=io_out.read(), err=io_err.read(), exit=exit)
+        return CmdResult(out=result, err=io_err.read(), exit_code=exit_code)
+
+    io_out.seek(0)
+    io_err.seek(0)
+    return CmdResult(out=io_out.read(), err=io_err.read(), exit_code=exit_code)
 
 
 def run(parser, command_string, kwargs=None, exit=False):
@@ -67,10 +67,9 @@ def run(parser, command_string, kwargs=None, exit=False):
     kwargs = kwargs or {}
     result = call_cmd(parser, command_string, **kwargs)
     if exit:
-        if result.exit is None:
+        if result.exit_code is None:
             raise AssertionError("Did not exit")
-        else:
-            return result.exit
+        return result.exit_code
     return result
 
 

--- a/tests/test_assembling.py
+++ b/tests/test_assembling.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 import argh
-from argh.assembling import AssemblingError
+from argh.assembling import AssemblingError, NameMappingPolicy
 from argh.dto import ParserAddArgumentSpec
 
 
@@ -86,7 +86,7 @@ def test_set_default_command():
             ParserAddArgumentSpec(
                 func_arg_name="foo",
                 cli_arg_names=("foo",),
-                nargs="+",
+                nargs=argparse.ONE_OR_MORE,
                 other_add_parser_kwargs={"choices": [1, 2], "help": "me"},
             ),
             ParserAddArgumentSpec(
@@ -103,7 +103,7 @@ def test_set_default_command():
     argh.set_default_command(parser, func)
 
     assert parser.add_argument.mock_calls == [
-        call("foo", nargs="+", choices=[1, 2], help="me", type=int),
+        call("foo", nargs=argparse.ONE_OR_MORE, choices=[1, 2], help="me", type=int),
         call(
             "-b",
             "--bar",
@@ -249,7 +249,7 @@ def test_set_default_command__declared_vs_signature__names_mismatch():
             ParserAddArgumentSpec(
                 func_arg_name="x",
                 cli_arg_names=("foo",),
-                nargs="+",
+                nargs=argparse.ONE_OR_MORE,
                 other_add_parser_kwargs={"choices": [1, 2], "help": "me"},
             ),
         ),
@@ -292,7 +292,8 @@ def test_set_default_command__declared_vs_signature__same_name_pos_vs_opt():
         argh.set_default_command(parser, func)
 
 
-def test_set_default_command_infer_cli_arg_names_from_func_signature():
+@pytest.fixture()
+def big_command_with_everything():
     # TODO: split into small tests where we'd check each combo and make sure
     # they interact as expected (e.g. pos opt arg gets the short form even if
     # there's a pos req arg, etc.)
@@ -320,35 +321,27 @@ def test_set_default_command_infer_cli_arg_names_from_func_signature():
         zeta_kwonly_opt="zeta kwonly",
         **kwargs,
     ):
-        return (
-            alpha_pos_req,
-            beta_pos_req,
-            alpha_pos_opt,
-            beta_pos_opt_one,
-            beta_pos_opt_two,
-            gamma_pos_opt,
-            delta_pos_opt,
-            theta_pos_opt,
-            gamma_kwonly_opt,
-            delta_kwonly_req,
-            epsilon_kwonly_req_one,
-            epsilon_kwonly_req_two,
-            zeta_kwonly_opt,
-            args,
-            kwargs,
-        )
+        return (alpha_pos_req, beta_pos_req, alpha_pos_opt, beta_pos_opt_one, beta_pos_opt_two, gamma_pos_opt, delta_pos_opt, theta_pos_opt, gamma_kwonly_opt, delta_kwonly_req, epsilon_kwonly_req_one, epsilon_kwonly_req_two, zeta_kwonly_opt, args, kwargs)
+
+    yield func
+
+
+def test_set_default_command_infer_cli_arg_names_from_func_signature__policy_legacy(big_command_with_everything):
+    name_mapping_policy = NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
 
     parser = argh.ArghParser()
 
     parser.add_argument = MagicMock()
     parser.set_defaults = MagicMock()
 
-    argh.set_default_command(parser, func)
+    argh.set_default_command(
+        parser, big_command_with_everything, name_mapping_policy=name_mapping_policy
+    )
 
     help_tmpl = argh.constants.DEFAULT_ARGUMENT_TEMPLATE
     assert parser.add_argument.mock_calls == [
-        call("alpha_pos_req", help="%(default)s"),
-        call("beta_pos_req", help="%(default)s"),
+        call("alpha-pos-req", help="%(default)s"),
+        call("beta-pos-req", help="%(default)s"),
         call("-a", "--alpha-pos-opt", default="alpha", type=str, help=help_tmpl),
         call("--beta-pos-opt-one", default="beta one", type=str, help=help_tmpl),
         call("--beta-pos-opt-two", default="beta two", type=str, help=help_tmpl),
@@ -356,15 +349,45 @@ def test_set_default_command_infer_cli_arg_names_from_func_signature():
         call("--delta-pos-opt", default="delta named", type=str, help=help_tmpl),
         call("-t", "--theta-pos-opt", default="theta named", type=str, help=help_tmpl),
         call("--gamma-kwonly-opt", default="gamma kwonly", type=str, help=help_tmpl),
+        call("delta-kwonly-req", help=help_tmpl),
+        call("epsilon-kwonly-req-one", help=help_tmpl),
+        call("epsilon-kwonly-req-two", help=help_tmpl),
+        call("-z", "--zeta-kwonly-opt", default="zeta kwonly", type=str, help=help_tmpl),
+        call("args", nargs=argparse.ZERO_OR_MORE, help=help_tmpl),
+    ]
+    assert parser.set_defaults.mock_calls == [call(function=big_command_with_everything)]
+
+
+def test_set_default_command_infer_cli_arg_names_from_func_signature__policy_modern(big_command_with_everything):
+    name_mapping_policy = NameMappingPolicy.BY_NAME_IF_KWONLY
+
+    parser = argh.ArghParser()
+
+    parser.add_argument = MagicMock()
+    parser.set_defaults = MagicMock()
+
+    argh.set_default_command(
+        parser, big_command_with_everything, name_mapping_policy=name_mapping_policy
+    )
+
+    help_tmpl = argh.constants.DEFAULT_ARGUMENT_TEMPLATE
+    assert parser.add_argument.mock_calls == [
+        call("alpha-pos-req", help="%(default)s"),
+        call("beta-pos-req", help="%(default)s"),
+        call("alpha-pos-opt", default="alpha", nargs=argparse.OPTIONAL, type=str, help=help_tmpl),
+        call("beta-pos-opt-one", default="beta one", nargs=argparse.OPTIONAL, type=str, help=help_tmpl),
+        call("beta-pos-opt-two", default="beta two", nargs=argparse.OPTIONAL, type=str, help=help_tmpl),
+        call("gamma-pos-opt", default="gamma named", nargs=argparse.OPTIONAL, type=str, help=help_tmpl),
+        call("delta-pos-opt", default="delta named", nargs=argparse.OPTIONAL, type=str, help=help_tmpl),
+        call("theta-pos-opt", default="theta named", nargs=argparse.OPTIONAL, type=str, help=help_tmpl),
+        call("--gamma-kwonly-opt", default="gamma kwonly", type=str, help=help_tmpl),
         call("--delta-kwonly-req", required=True, help=help_tmpl),
         call("--epsilon-kwonly-req-one", required=True, help=help_tmpl),
         call("--epsilon-kwonly-req-two", required=True, help=help_tmpl),
-        call(
-            "-z", "--zeta-kwonly-opt", default="zeta kwonly", type=str, help=help_tmpl
-        ),
-        call("args", nargs="*", help=help_tmpl),
+        call("-z", "--zeta-kwonly-opt", default="zeta kwonly", type=str, help=help_tmpl),
+        call("args", nargs=argparse.ZERO_OR_MORE, help=help_tmpl),
     ]
-    assert parser.set_defaults.mock_calls == [call(function=func)]
+    assert parser.set_defaults.mock_calls == [call(function=big_command_with_everything)]
 
 
 def test_set_default_command_docstring():
@@ -377,6 +400,21 @@ def test_set_default_command_docstring():
     argh.set_default_command(parser, func)
 
     assert parser.description == "docstring"
+
+
+def test_set_default_command__varkwargs_sharing_prefix():
+    def func(*, alpha: str = "Alpha", aleph: str = "Aleph"):
+        ...
+
+    parser = argh.ArghParser()
+    parser.add_argument = MagicMock()
+
+    argh.set_default_command(parser, func)
+
+    assert parser.add_argument.mock_calls == [
+        call("--alpha", default="Alpha", type=str, help="%(default)s"),
+        call("--aleph", default="Aleph", type=str, help="%(default)s")
+    ]
 
 
 def test_add_subparsers_when_default_command_exists():
@@ -465,7 +503,7 @@ def test_set_default_command_varargs():
     argh.set_default_command(parser, func)
 
     assert parser.add_argument.mock_calls == [
-        call("file_paths", nargs="*", help=argh.constants.DEFAULT_ARGUMENT_TEMPLATE),
+        call("file-paths", nargs=argparse.ZERO_OR_MORE, help=argh.constants.DEFAULT_ARGUMENT_TEMPLATE),
     ]
 
 
@@ -488,22 +526,42 @@ def test_set_default_command_kwargs():
     ]
 
 
-def test_kwonlyargs():
+
+def test_kwonlyargs__policy_legacy():
     "Correctly processing required and optional keyword-only arguments"
 
     def cmd(foo_pos, bar_pos, *args, foo_kwonly="foo_kwonly", bar_kwonly):
         return (foo_pos, bar_pos, args, foo_kwonly, bar_kwonly)
 
-    p = argh.ArghParser()
-    p.add_argument = MagicMock()
-    p.set_default_command(cmd)
+    parser = argh.ArghParser()
+    parser.add_argument = MagicMock()
+    parser.set_default_command(cmd, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT)
     help_tmpl = argh.constants.DEFAULT_ARGUMENT_TEMPLATE
-    assert p.add_argument.mock_calls == [
-        call("foo_pos", help=help_tmpl),
-        call("bar_pos", help=help_tmpl),
+    assert parser.add_argument.mock_calls == [
+        call("foo-pos", help=help_tmpl),
+        call("bar-pos", help=help_tmpl),
+        call("-f", "--foo-kwonly", default="foo_kwonly", type=str, help=help_tmpl),
+        call("bar-kwonly", help=help_tmpl),
+        call("args", nargs=argparse.ZERO_OR_MORE, help=help_tmpl),
+    ]
+
+
+def test_kwonlyargs__policy_modern():
+    "Correctly processing required and optional keyword-only arguments"
+
+    def cmd(foo_pos, bar_pos, *args, foo_kwonly="foo_kwonly", bar_kwonly):
+        return (foo_pos, bar_pos, args, foo_kwonly, bar_kwonly)
+
+    parser = argh.ArghParser()
+    parser.add_argument = MagicMock()
+    parser.set_default_command(cmd, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_KWONLY)
+    help_tmpl = argh.constants.DEFAULT_ARGUMENT_TEMPLATE
+    assert parser.add_argument.mock_calls == [
+        call("foo-pos", help=help_tmpl),
+        call("bar-pos", help=help_tmpl),
         call("-f", "--foo-kwonly", default="foo_kwonly", type=str, help=help_tmpl),
         call("-b", "--bar-kwonly", required=True, help=help_tmpl),
-        call("args", nargs="*", help=help_tmpl),
+        call("args", nargs=argparse.ZERO_OR_MORE, help=help_tmpl),
     ]
 
 

--- a/tests/test_assembling.py
+++ b/tests/test_assembling.py
@@ -52,13 +52,21 @@ def test_guess_type_from_default():
 
 
 def test_guess_action_from_default():
-    # True → store_false
+    # positional, default True → ignore
     given = ParserAddArgumentSpec("foo", ["foo"], default_value=False)
+    assert {} == argh.assembling.guess_extra_parser_add_argument_spec_kwargs(given)
+
+    # named, default True → store_false
+    given = ParserAddArgumentSpec("foo", ["--foo"], default_value=False)
     guessed = {"action": "store_true"}
     assert guessed == argh.assembling.guess_extra_parser_add_argument_spec_kwargs(given)
 
-    # True → store_false
+    # positional, default False → ignore
     given = ParserAddArgumentSpec("foo", ["foo"], default_value=True)
+    assert {} == argh.assembling.guess_extra_parser_add_argument_spec_kwargs(given)
+
+    # named, True → store_false
+    given = ParserAddArgumentSpec("foo", ["--foo"], default_value=True)
     guessed = {"action": "store_false"}
     assert guessed == argh.assembling.guess_extra_parser_add_argument_spec_kwargs(given)
 
@@ -73,6 +81,26 @@ def test_guess_action_from_default():
     )
     guessed = {}
     assert guessed == argh.assembling.guess_extra_parser_add_argument_spec_kwargs(given)
+
+
+def test_positional_with_default_int():
+    def func(pos_int_default=123):
+        ...
+
+    parser = argh.ArghParser()
+    parser.set_default_command(func)
+    assert parser.format_usage() == "usage: pytest [-h] [pos-int-default]\n"
+    assert "pos-int-default  123" in parser.format_help()
+
+
+def test_positional_with_default_bool():
+    def func(pos_bool_default=False):
+        ...
+
+    parser = argh.ArghParser()
+    parser.set_default_command(func)
+    assert parser.format_usage() == "usage: pytest [-h] [pos-bool-default]\n"
+    assert "pos-bool-default  False" in parser.format_help()
 
 
 def test_set_default_command():

--- a/tests/test_assembling.py
+++ b/tests/test_assembling.py
@@ -87,9 +87,9 @@ def test_positional_with_default_int():
     def func(pos_int_default=123):
         ...
 
-    parser = argh.ArghParser()
+    parser = argh.ArghParser(prog="test")
     parser.set_default_command(func)
-    assert parser.format_usage() == "usage: pytest [-h] [pos-int-default]\n"
+    assert parser.format_usage() == "usage: test [-h] [pos-int-default]\n"
     assert "pos-int-default  123" in parser.format_help()
 
 
@@ -97,9 +97,9 @@ def test_positional_with_default_bool():
     def func(pos_bool_default=False):
         ...
 
-    parser = argh.ArghParser()
+    parser = argh.ArghParser(prog="test")
     parser.set_default_command(func)
-    assert parser.format_usage() == "usage: pytest [-h] [pos-bool-default]\n"
+    assert parser.format_usage() == "usage: test [-h] [pos-bool-default]\n"
     assert "pos-bool-default  False" in parser.format_help()
 
 

--- a/tests/test_assembling.py
+++ b/tests/test_assembling.py
@@ -321,12 +321,30 @@ def big_command_with_everything():
         zeta_kwonly_opt="zeta kwonly",
         **kwargs,
     ):
-        return (alpha_pos_req, beta_pos_req, alpha_pos_opt, beta_pos_opt_one, beta_pos_opt_two, gamma_pos_opt, delta_pos_opt, theta_pos_opt, gamma_kwonly_opt, delta_kwonly_req, epsilon_kwonly_req_one, epsilon_kwonly_req_two, zeta_kwonly_opt, args, kwargs)
+        return (
+            alpha_pos_req,
+            beta_pos_req,
+            alpha_pos_opt,
+            beta_pos_opt_one,
+            beta_pos_opt_two,
+            gamma_pos_opt,
+            delta_pos_opt,
+            theta_pos_opt,
+            gamma_kwonly_opt,
+            delta_kwonly_req,
+            epsilon_kwonly_req_one,
+            epsilon_kwonly_req_two,
+            zeta_kwonly_opt,
+            args,
+            kwargs,
+        )
 
     yield func
 
 
-def test_set_default_command_infer_cli_arg_names_from_func_signature__policy_legacy(big_command_with_everything):
+def test_set_default_command_infer_cli_arg_names_from_func_signature__policy_legacy(
+    big_command_with_everything,
+):
     name_mapping_policy = NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
 
     parser = argh.ArghParser()
@@ -352,13 +370,19 @@ def test_set_default_command_infer_cli_arg_names_from_func_signature__policy_leg
         call("delta-kwonly-req", help=help_tmpl),
         call("epsilon-kwonly-req-one", help=help_tmpl),
         call("epsilon-kwonly-req-two", help=help_tmpl),
-        call("-z", "--zeta-kwonly-opt", default="zeta kwonly", type=str, help=help_tmpl),
+        call(
+            "-z", "--zeta-kwonly-opt", default="zeta kwonly", type=str, help=help_tmpl
+        ),
         call("args", nargs=argparse.ZERO_OR_MORE, help=help_tmpl),
     ]
-    assert parser.set_defaults.mock_calls == [call(function=big_command_with_everything)]
+    assert parser.set_defaults.mock_calls == [
+        call(function=big_command_with_everything)
+    ]
 
 
-def test_set_default_command_infer_cli_arg_names_from_func_signature__policy_modern(big_command_with_everything):
+def test_set_default_command_infer_cli_arg_names_from_func_signature__policy_modern(
+    big_command_with_everything,
+):
     name_mapping_policy = NameMappingPolicy.BY_NAME_IF_KWONLY
 
     parser = argh.ArghParser()
@@ -374,20 +398,60 @@ def test_set_default_command_infer_cli_arg_names_from_func_signature__policy_mod
     assert parser.add_argument.mock_calls == [
         call("alpha-pos-req", help="%(default)s"),
         call("beta-pos-req", help="%(default)s"),
-        call("alpha-pos-opt", default="alpha", nargs=argparse.OPTIONAL, type=str, help=help_tmpl),
-        call("beta-pos-opt-one", default="beta one", nargs=argparse.OPTIONAL, type=str, help=help_tmpl),
-        call("beta-pos-opt-two", default="beta two", nargs=argparse.OPTIONAL, type=str, help=help_tmpl),
-        call("gamma-pos-opt", default="gamma named", nargs=argparse.OPTIONAL, type=str, help=help_tmpl),
-        call("delta-pos-opt", default="delta named", nargs=argparse.OPTIONAL, type=str, help=help_tmpl),
-        call("theta-pos-opt", default="theta named", nargs=argparse.OPTIONAL, type=str, help=help_tmpl),
+        call(
+            "alpha-pos-opt",
+            default="alpha",
+            nargs=argparse.OPTIONAL,
+            type=str,
+            help=help_tmpl,
+        ),
+        call(
+            "beta-pos-opt-one",
+            default="beta one",
+            nargs=argparse.OPTIONAL,
+            type=str,
+            help=help_tmpl,
+        ),
+        call(
+            "beta-pos-opt-two",
+            default="beta two",
+            nargs=argparse.OPTIONAL,
+            type=str,
+            help=help_tmpl,
+        ),
+        call(
+            "gamma-pos-opt",
+            default="gamma named",
+            nargs=argparse.OPTIONAL,
+            type=str,
+            help=help_tmpl,
+        ),
+        call(
+            "delta-pos-opt",
+            default="delta named",
+            nargs=argparse.OPTIONAL,
+            type=str,
+            help=help_tmpl,
+        ),
+        call(
+            "theta-pos-opt",
+            default="theta named",
+            nargs=argparse.OPTIONAL,
+            type=str,
+            help=help_tmpl,
+        ),
         call("--gamma-kwonly-opt", default="gamma kwonly", type=str, help=help_tmpl),
         call("--delta-kwonly-req", required=True, help=help_tmpl),
         call("--epsilon-kwonly-req-one", required=True, help=help_tmpl),
         call("--epsilon-kwonly-req-two", required=True, help=help_tmpl),
-        call("-z", "--zeta-kwonly-opt", default="zeta kwonly", type=str, help=help_tmpl),
+        call(
+            "-z", "--zeta-kwonly-opt", default="zeta kwonly", type=str, help=help_tmpl
+        ),
         call("args", nargs=argparse.ZERO_OR_MORE, help=help_tmpl),
     ]
-    assert parser.set_defaults.mock_calls == [call(function=big_command_with_everything)]
+    assert parser.set_defaults.mock_calls == [
+        call(function=big_command_with_everything)
+    ]
 
 
 def test_set_default_command_docstring():
@@ -413,7 +477,7 @@ def test_set_default_command__varkwargs_sharing_prefix():
 
     assert parser.add_argument.mock_calls == [
         call("--alpha", default="Alpha", type=str, help="%(default)s"),
-        call("--aleph", default="Aleph", type=str, help="%(default)s")
+        call("--aleph", default="Aleph", type=str, help="%(default)s"),
     ]
 
 
@@ -503,7 +567,11 @@ def test_set_default_command_varargs():
     argh.set_default_command(parser, func)
 
     assert parser.add_argument.mock_calls == [
-        call("file-paths", nargs=argparse.ZERO_OR_MORE, help=argh.constants.DEFAULT_ARGUMENT_TEMPLATE),
+        call(
+            "file-paths",
+            nargs=argparse.ZERO_OR_MORE,
+            help=argh.constants.DEFAULT_ARGUMENT_TEMPLATE,
+        ),
     ]
 
 
@@ -526,7 +594,6 @@ def test_set_default_command_kwargs():
     ]
 
 
-
 def test_kwonlyargs__policy_legacy():
     "Correctly processing required and optional keyword-only arguments"
 
@@ -535,7 +602,9 @@ def test_kwonlyargs__policy_legacy():
 
     parser = argh.ArghParser()
     parser.add_argument = MagicMock()
-    parser.set_default_command(cmd, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT)
+    parser.set_default_command(
+        cmd, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+    )
     help_tmpl = argh.constants.DEFAULT_ARGUMENT_TEMPLATE
     assert parser.add_argument.mock_calls == [
         call("foo-pos", help=help_tmpl),
@@ -554,7 +623,9 @@ def test_kwonlyargs__policy_modern():
 
     parser = argh.ArghParser()
     parser.add_argument = MagicMock()
-    parser.set_default_command(cmd, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_KWONLY)
+    parser.set_default_command(
+        cmd, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_KWONLY
+    )
     help_tmpl = argh.constants.DEFAULT_ARGUMENT_TEMPLATE
     assert parser.add_argument.mock_calls == [
         call("foo-pos", help=help_tmpl),

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -672,10 +672,13 @@ def test_kwonlyargs__policy_legacy():
         cmd, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
     )
 
-    assert (
-        parser.format_usage()
-        == "usage: pytest [-h] [-f FOO] [--baz BAZ] bar [args ...]\n"
-    )
+    expected_usage = "usage: pytest [-h] [-f FOO] [--baz BAZ] bar [args ...]\n"
+    if sys.version_info < (3, 9):
+        # https://github.com/python/cpython/issues/82619
+        expected_usage = (
+            "usage: pytest [-h] [-f FOO] [--baz BAZ] bar [args [args ...]]\n"
+        )
+    assert parser.format_usage() == expected_usage
 
     assert (
         run(parser, "--baz=done test  this --baz=do").out
@@ -698,10 +701,13 @@ def test_kwonlyargs__policy_modern():
         cmd, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_KWONLY
     )
 
-    assert (
-        parser.format_usage()
-        == "usage: pytest [-h] [-f FOO] --bar BAR [--baz BAZ] [args ...]\n"
-    )
+    expected_usage = "usage: pytest [-h] [-f FOO] --bar BAR [--baz BAZ] [args ...]\n"
+    if sys.version_info < (3, 9):
+        # https://github.com/python/cpython/issues/82619
+        expected_usage = (
+            "usage: pytest [-h] [-f FOO] --bar BAR [--baz BAZ] [args [args ...]]\n"
+        )
+    assert parser.format_usage() == expected_usage
 
     assert (
         run(parser, "--baz=done test  this --bar=do").out

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -29,7 +29,9 @@ def test_set_default_command_integration():
         return foo
 
     parser = DebugArghParser()
-    parser.set_default_command(cmd)
+    parser.set_default_command(
+        cmd, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+    )
 
     assert run(parser, "") == R(out="1\n", err="")
     assert run(parser, "--foo 2") == R(out="2\n", err="")
@@ -42,7 +44,9 @@ def test_set_default_command_integration_merging():
         return foo
 
     parser = DebugArghParser()
-    parser.set_default_command(cmd)
+    parser.set_default_command(
+        cmd, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+    )
 
     assert run(parser, "") == R(out="1\n", err="")
     assert run(parser, "--foo 2") == R(out="2\n", err="")
@@ -80,7 +84,9 @@ def test_simple_function_defaults():
         yield x
 
     parser = DebugArghParser()
-    parser.set_default_command(cmd)
+    parser.set_default_command(
+        cmd, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+    )
 
     assert run(parser, "") == R(out="foo\n", err="")
     assert run(parser, "bar", exit=True) == "unrecognized arguments: bar"
@@ -132,7 +138,9 @@ def test_all_specs_in_one():
             yield f"** {k}: {kwargs[k]}"
 
     parser = DebugArghParser()
-    parser.set_default_command(cmd)
+    parser.set_default_command(
+        cmd, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+    )
 
     # 1) bar=1 is treated as --bar so positionals from @arg that go **kwargs
     #    will still have higher priority than bar.
@@ -175,7 +183,9 @@ def test_arg_merged():
         return my, brain, "hurts"
 
     parser = DebugArghParser("PROG")
-    parser.set_default_command(gumby)
+    parser.set_default_command(
+        gumby, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+    )
     help_msg = parser.format_help()
 
     assert "a moose once bit my sister" in help_msg
@@ -191,7 +201,9 @@ def test_arg_mismatch_positional():
 
     parser = DebugArghParser("PROG")
     with pytest.raises(AssemblingError) as excinfo:
-        parser.set_default_command(confuse_a_cat)
+        parser.set_default_command(
+            confuse_a_cat, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+        )
 
     msg = (
         "confuse_a_cat: argument bogus-argument does not fit "
@@ -209,7 +221,9 @@ def test_arg_mismatch_flag():
 
     parser = DebugArghParser("PROG")
     with pytest.raises(AssemblingError) as excinfo:
-        parser.set_default_command(confuse_a_cat)
+        parser.set_default_command(
+            confuse_a_cat, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+        )
 
     msg = (
         "confuse_a_cat: argument --bogus-argument does not fit "
@@ -227,7 +241,9 @@ def test_arg_mismatch_positional_vs_flag():
 
     parser = DebugArghParser("PROG")
     with pytest.raises(AssemblingError) as excinfo:
-        parser.set_default_command(func)
+        parser.set_default_command(
+            func, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+        )
 
     msg = (
         'func: argument "foo" declared as optional (in function signature)'
@@ -268,7 +284,9 @@ class TestErrorWrapping:
         parrot = self._get_parrot()
 
         parser = DebugArghParser()
-        parser.set_default_command(parrot)
+        parser.set_default_command(
+            parrot, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+        )
 
         assert run(parser, "") == R("beautiful plumage\n", "")
         with pytest.raises(ValueError) as excinfo:
@@ -280,7 +298,9 @@ class TestErrorWrapping:
         wrapped_parrot = argh.wrap_errors([ValueError])(parrot)
 
         parser = DebugArghParser()
-        parser.set_default_command(wrapped_parrot)
+        parser.set_default_command(
+            wrapped_parrot, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+        )
 
         assert run(parser, "") == R("beautiful plumage\n", "")
         assert run(parser, "--dead") == R(
@@ -297,7 +317,10 @@ class TestErrorWrapping:
         processed_parrot = argh.wrap_errors(processor=failure)(wrapped_parrot)
 
         parser = argh.ArghParser()
-        parser.set_default_command(processed_parrot)
+        parser.set_default_command(
+            processed_parrot,
+            name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT,
+        )
 
         assert run(parser, "--dead") == R(
             "", "ERR: this parrot is no more!\n", exit_code=1
@@ -310,7 +333,9 @@ class TestErrorWrapping:
             return db[key]
 
         parser = argh.ArghParser()
-        parser.set_default_command(func)
+        parser.set_default_command(
+            func, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+        )
 
         assert run(parser, "a") == R(out="1\n", err="")
         assert run(parser, "b") == R(out="", err="KeyError: 'b'\n", exit_code=1)
@@ -417,7 +442,9 @@ def test_bool_action():
         return "this parrot is no more" if dead else "beautiful plumage"
 
     parser = DebugArghParser()
-    parser.add_commands([parrot])
+    parser.add_commands(
+        [parrot], name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+    )
 
     assert run(parser, "parrot").out == "beautiful plumage\n"
     assert run(parser, "parrot --dead").out == "this parrot is no more\n"
@@ -454,7 +481,11 @@ def test_function_under_group_name():
         return f"Howdy {buddy}?"
 
     parser = DebugArghParser()
-    parser.add_commands([hello, howdy], group_name="greet")
+    parser.add_commands(
+        [hello, howdy],
+        group_name="greet",
+        name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT,
+    )
 
     assert run(parser, "greet hello").out == "Hello world!\n"
     assert run(parser, "greet hello --name=John").out == "Hello John!\n"
@@ -546,7 +577,10 @@ def test_command_error():
         raise argh.CommandError("I feel depressed.")
 
     parser = DebugArghParser()
-    parser.add_commands([whiner_plain, whiner_iterable])
+    parser.add_commands(
+        [whiner_plain, whiner_iterable],
+        name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT,
+    )
 
     assert run(parser, "whiner-plain") == R(
         out="", err="CommandError: I feel depressed.\n", exit_code=1
@@ -732,7 +766,9 @@ def test_default_arg_values_in_help():
         return "Oh what is it now, can't you leave me in peace..."
 
     parser = DebugArghParser()
-    parser.set_default_command(remind)
+    parser.set_default_command(
+        remind, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+    )
 
     assert "Basil" in parser.format_help()
     assert "Moose" in parser.format_help()
@@ -751,7 +787,9 @@ def test_default_arg_values_in_help__regression():
         return bar
 
     parser = DebugArghParser()
-    parser.set_default_command(foo)
+    parser.set_default_command(
+        foo, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+    )
 
     # doesn't break
     parser.format_help()
@@ -803,7 +841,9 @@ def test_unknown_args():
         return foo
 
     parser = DebugArghParser()
-    parser.set_default_command(cmd)
+    parser.set_default_command(
+        cmd, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+    )
 
     get_usage_string("[-f FOO]")
 
@@ -874,6 +914,7 @@ def test_add_commands_no_overrides2(capsys: pytest.CaptureFixture[str]):
     parser = argh.ArghParser(prog="myapp")
     parser.add_commands(
         [first_func, second_func],
+        name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT,
     )
 
     run(parser, "first-func --help", exit=True)
@@ -957,6 +998,7 @@ def test_add_commands_group_overrides2(capsys: pytest.CaptureFixture[str]):
             "help": "group help override",
             "description": "group description override",
         },
+        name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT,
     )
 
     run(parser, "my-group --help", exit=True)
@@ -1003,6 +1045,7 @@ def test_add_commands_group_overrides3(capsys: pytest.CaptureFixture[str]):
             "help": "group help override",
             "description": "group description override",
         },
+        name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT,
     )
 
     run(parser, "my-group first-func --help", exit=True)
@@ -1043,6 +1086,7 @@ def test_add_commands_func_overrides1(capsys: pytest.CaptureFixture[str]):
             "help": "func help override",
             "description": "func description override",
         },
+        name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT,
     )
 
     run(parser, "--help", exit=True)
@@ -1085,6 +1129,7 @@ def test_add_commands_func_overrides2(capsys: pytest.CaptureFixture[str]):
             "help": "func help override",
             "description": "func description override",
         },
+        name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT,
     )
 
     run(parser, "first-func --help", exit=True)
@@ -1125,7 +1170,9 @@ def test_action_count__mixed():
         return f"verbosity: {verbose}"
 
     parser = DebugArghParser()
-    parser.set_default_command(func)
+    parser.set_default_command(
+        func, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+    )
 
     assert run(parser, "").out == "verbosity: 0\n"
     assert run(parser, "-v").out == "verbosity: 1\n"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,6 +6,7 @@ import argparse
 import re
 import sys
 import unittest.mock as mock
+from enum import Enum
 
 import pytest
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -298,8 +298,9 @@ class TestErrorWrapping:
         parser = argh.ArghParser()
         parser.set_default_command(processed_parrot)
 
-        assert run(parser, "--dead") == R("", "ERR: this parrot is no more!\n",
-                                          exit_code=1)
+        assert run(parser, "--dead") == R(
+            "", "ERR: this parrot is no more!\n", exit_code=1
+        )
 
     def test_stderr_vs_stdout(self):
         @argh.wrap_errors([KeyError])
@@ -665,16 +666,24 @@ def test_kwonlyargs__policy_legacy():
     def cmd(*args, foo="1", bar, baz="3", **kwargs):
         return f"foo='{foo}' bar='{bar}' baz='{baz}' args={args} kwargs={kwargs}"
 
-    parser = DebugArghParser()
-    parser.set_default_command(cmd, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT)
+    parser = DebugArghParser(prog="pytest")
+    parser.set_default_command(
+        cmd, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+    )
 
-    assert parser.format_usage() == "usage: pytest [-h] [-f FOO] [--baz BAZ] bar [args ...]\n"
+    assert (
+        parser.format_usage()
+        == "usage: pytest [-h] [-f FOO] [--baz BAZ] bar [args ...]\n"
+    )
 
     assert (
         run(parser, "--baz=done test  this --baz=do").out
         == "foo='1' bar='test' baz='do' args=('this',) kwargs={}\n"
     )
-    assert run(parser, "test --foo=do").out == "foo='do' bar='test' baz='3' args=() kwargs={}\n"
+    assert (
+        run(parser, "test --foo=do").out
+        == "foo='do' bar='test' baz='3' args=() kwargs={}\n"
+    )
 
 
 def test_kwonlyargs__policy_modern():
@@ -683,10 +692,15 @@ def test_kwonlyargs__policy_modern():
     def cmd(*args, foo="1", bar, baz="3", **kwargs):
         return f"foo='{foo}' bar='{bar}' baz='{baz}' args={args} kwargs={kwargs}"
 
-    parser = DebugArghParser()
-    parser.set_default_command(cmd, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_KWONLY)
+    parser = DebugArghParser(prog="pytest")
+    parser.set_default_command(
+        cmd, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_KWONLY
+    )
 
-    assert parser.format_usage() == "usage: pytest [-h] [-f FOO] --bar BAR [--baz BAZ] [args ...]\n"
+    assert (
+        parser.format_usage()
+        == "usage: pytest [-h] [-f FOO] --bar BAR [--baz BAZ] [args ...]\n"
+    )
 
     assert (
         run(parser, "--baz=done test  this --bar=do").out

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -807,6 +807,22 @@ def test_unknown_args():
     )
 
 
+def test_add_commands_unknown_name_mapping_policy():
+    def func(foo):
+        ...
+
+    parser = argh.ArghParser(prog="myapp")
+
+    class UnsuitablePolicyContainer(Enum):
+        FOO = "Ni!!!"
+
+    with pytest.raises(
+        NotImplementedError,
+        match="Unknown name mapping policy UnsuitablePolicyContainer.FOO",
+    ):
+        parser.add_commands([func], name_mapping_policy=UnsuitablePolicyContainer.FOO)
+
+
 def test_add_commands_no_overrides1(capsys: pytest.CaptureFixture[str]):
     def first_func(foo=123):
         """Owl stretching time"""

--- a/tests/test_mapping_policies.py
+++ b/tests/test_mapping_policies.py
@@ -1,0 +1,133 @@
+from argparse import ArgumentParser, Namespace
+from typing import Callable
+import pytest
+
+from argh.assembling import DefaultsPolicies, infer_argspecs_from_function
+
+
+@pytest.mark.parametrize("defaults_policy", list(DefaultsPolicies))
+def test_no_args(defaults_policy) -> None:
+    def func() -> None:
+        ...
+
+    parser = _make_parser_for_function(func, defaults_policy=defaults_policy)
+    assert_usage(parser, "usage: test [-h]\n")
+
+
+@pytest.mark.parametrize("defaults_policy", list(DefaultsPolicies))
+def test_one_positional(defaults_policy) -> None:
+    def func(alpha: str) -> str:
+        return f"{alpha}"
+
+    parser = _make_parser_for_function(func, defaults_policy=defaults_policy)
+    assert_usage(parser, "usage: test [-h] alpha\n")
+    assert_parsed(parser, ["hello"], Namespace(alpha="hello"))
+
+
+@pytest.mark.parametrize("defaults_policy", list(DefaultsPolicies))
+def test_two_positionals(defaults_policy) -> None:
+    def func(alpha: str, beta: str) -> str:
+        return f"{alpha}, {beta}"
+
+    parser = _make_parser_for_function(func, defaults_policy=defaults_policy)
+    assert_usage(parser, "usage: test [-h] alpha beta\n")
+    assert_parsed(parser, ["one", "two"], Namespace(alpha="one", beta="two"))
+
+
+@pytest.mark.parametrize("defaults_policy,expected_usage", [
+    (DefaultsPolicies.BASIC, "usage: test [-h] [-b BETA] alpha\n"),
+    (DefaultsPolicies.KWONLY, "usage: test [-h] alpha [beta]\n"),
+])
+def test_two_positionals_one_with_default(defaults_policy, expected_usage) -> None:
+    def func(alpha: str, beta: int = 123) -> str:
+        return f"{alpha}, {beta}"
+
+    parser = _make_parser_for_function(func, defaults_policy=defaults_policy)
+    assert_usage(parser, expected_usage)
+
+    assert_parsed(parser, ["one"], Namespace(alpha="one", beta=123))
+    if defaults_policy == DefaultsPolicies.BASIC:
+        assert_parsed(parser, ["one", "--beta", "two"], Namespace(alpha="one", beta="two"))
+    elif defaults_policy == DefaultsPolicies.KWONLY:
+        assert_parsed(parser, ["one", "two"], Namespace(alpha="one", beta="two"))
+
+
+@pytest.mark.parametrize("defaults_policy", list(DefaultsPolicies))
+def test_varargs(defaults_policy) -> None:
+
+    def func(*file_paths) -> str:
+        return f"{file_paths}"
+
+    parser = _make_parser_for_function(func, defaults_policy=defaults_policy)
+    assert_usage(parser, "usage: test [-h] [file_paths ...]\n")
+
+
+@pytest.mark.parametrize("defaults_policy,expected_usage", [
+    (DefaultsPolicies.BASIC, "usage: test [-h] -b BETA alpha\n"),
+    (DefaultsPolicies.KWONLY, "usage: test [-h] -b BETA alpha\n"),
+])
+def test_varargs_between_positional_and_kwonly__no_defaults(defaults_policy, expected_usage) -> None:
+
+    def func(alpha, *, beta) -> str:
+        return f"{alpha}, {beta}"
+
+    parser = _make_parser_for_function(func, defaults_policy=defaults_policy)
+    assert_usage(parser, expected_usage)
+
+
+@pytest.mark.parametrize("defaults_policy,expected_usage", [
+    (DefaultsPolicies.BASIC, "usage: test [-h] [-a ALPHA] [-b BETA]\n"),
+    (DefaultsPolicies.KWONLY, "usage: test [-h] [-b BETA] [alpha]\n"),
+])
+def test_varargs_between_positional_and_kwonly__with_defaults(defaults_policy, expected_usage) -> None:
+
+    def func(alpha: int = 1, *, beta: int = 2) -> str:
+        return f"{alpha}, {beta}"
+
+    parser = _make_parser_for_function(func, defaults_policy=defaults_policy)
+    assert_usage(parser, expected_usage)
+
+
+def test_kwargs() -> None:
+
+    def func(**kwargs) -> str:
+        return f"{kwargs}"
+
+    parser = _make_parser_for_function(func, defaults_policy=DefaultsPolicies.KWONLY)
+    assert_usage(parser, "usage: test [-h]\n")
+
+
+@pytest.mark.parametrize("defaults_policy,expected_usage", [
+    (DefaultsPolicies.BASIC, "usage: test [-h] [-b BETA] -g GAMMA [-d DELTA] alpha\n"),
+    (DefaultsPolicies.KWONLY, "usage: test [-h] -g GAMMA [-d DELTA] alpha [beta]\n"),
+])
+def test_all_types_mixed_no_named_varargs(defaults_policy, expected_usage) -> None:
+
+    def func(alpha: str, beta: int = 1, *, gamma: str, delta: int = 2) -> str:
+        return f"{alpha}, {beta}, {gamma}, {delta}"
+
+    parser = _make_parser_for_function(func, defaults_policy=defaults_policy)
+    assert_usage(parser, expected_usage)
+
+
+def _make_parser_for_function(
+    func: Callable, defaults_policy: str = DefaultsPolicies.BASIC
+) -> ArgumentParser:
+    parser = ArgumentParser(prog="test")
+    parser_add_argument_specs = infer_argspecs_from_function(
+        function=func, defaults_policy=defaults_policy
+    )
+    for parser_add_argument_spec in parser_add_argument_specs:
+        parser.add_argument(
+            *parser_add_argument_spec.cli_arg_names,
+            **parser_add_argument_spec.get_all_kwargs()
+        )
+    return parser
+
+
+def assert_usage(parser: ArgumentParser, expected_usage: str) -> None:
+    assert expected_usage == parser.format_usage()
+
+def assert_parsed(parser: ArgumentParser, argv: list[str], expected_result: Namespace) -> None:
+    parsed = parser.parse_args(argv)
+    assert parsed == expected_result

--- a/tests/test_mapping_policies.py
+++ b/tests/test_mapping_policies.py
@@ -1,5 +1,5 @@
 from argparse import ArgumentParser, Namespace
-from typing import Callable
+from typing import Callable, List
 
 import pytest
 
@@ -159,7 +159,7 @@ def assert_usage(parser: ArgumentParser, expected_usage: str) -> None:
 
 
 def assert_parsed(
-    parser: ArgumentParser, argv: list[str], expected_result: Namespace
+    parser: ArgumentParser, argv: List[str], expected_result: Namespace
 ) -> None:
     parsed = parser.parse_args(argv)
     assert parsed == expected_result

--- a/tests/test_mapping_policies.py
+++ b/tests/test_mapping_policies.py
@@ -1,5 +1,6 @@
 from argparse import ArgumentParser, Namespace
 from typing import Callable
+
 import pytest
 
 from argh.assembling import NameMappingPolicy, infer_argspecs_from_function
@@ -34,10 +35,16 @@ def test_two_positionals(name_mapping_policy) -> None:
     assert_parsed(parser, ["one", "two"], Namespace(alpha="one", beta="two"))
 
 
-@pytest.mark.parametrize("name_mapping_policy,expected_usage", [
-    (NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT, "usage: test [-h] [-b BETA] alpha\n"),
-    (NameMappingPolicy.BY_NAME_IF_KWONLY, "usage: test [-h] alpha [beta]\n"),
-])
+@pytest.mark.parametrize(
+    "name_mapping_policy,expected_usage",
+    [
+        (
+            NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT,
+            "usage: test [-h] [-b BETA] alpha\n",
+        ),
+        (NameMappingPolicy.BY_NAME_IF_KWONLY, "usage: test [-h] alpha [beta]\n"),
+    ],
+)
 def test_two_positionals_one_with_default(name_mapping_policy, expected_usage) -> None:
     def func(alpha: str, beta: int = 123) -> str:
         return f"{alpha}, {beta}"
@@ -47,14 +54,15 @@ def test_two_positionals_one_with_default(name_mapping_policy, expected_usage) -
 
     assert_parsed(parser, ["one"], Namespace(alpha="one", beta=123))
     if name_mapping_policy == NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT:
-        assert_parsed(parser, ["one", "--beta", "two"], Namespace(alpha="one", beta="two"))
+        assert_parsed(
+            parser, ["one", "--beta", "two"], Namespace(alpha="one", beta="two")
+        )
     elif name_mapping_policy == NameMappingPolicy.BY_NAME_IF_KWONLY:
         assert_parsed(parser, ["one", "two"], Namespace(alpha="one", beta="two"))
 
 
 @pytest.mark.parametrize("name_mapping_policy", list(NameMappingPolicy))
 def test_varargs(name_mapping_policy) -> None:
-
     def func(*file_paths) -> str:
         return f"{file_paths}"
 
@@ -62,12 +70,16 @@ def test_varargs(name_mapping_policy) -> None:
     assert_usage(parser, "usage: test [-h] [file-paths ...]\n")
 
 
-@pytest.mark.parametrize("name_mapping_policy,expected_usage", [
-    (NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT, "usage: test [-h] alpha beta\n"),
-    (NameMappingPolicy.BY_NAME_IF_KWONLY, "usage: test [-h] -b BETA alpha\n"),
-])
-def test_varargs_between_positional_and_kwonly__no_defaults(name_mapping_policy, expected_usage) -> None:
-
+@pytest.mark.parametrize(
+    "name_mapping_policy,expected_usage",
+    [
+        (NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT, "usage: test [-h] alpha beta\n"),
+        (NameMappingPolicy.BY_NAME_IF_KWONLY, "usage: test [-h] -b BETA alpha\n"),
+    ],
+)
+def test_varargs_between_positional_and_kwonly__no_defaults(
+    name_mapping_policy, expected_usage
+) -> None:
     def func(alpha, *, beta) -> str:
         return f"{alpha}, {beta}"
 
@@ -75,12 +87,19 @@ def test_varargs_between_positional_and_kwonly__no_defaults(name_mapping_policy,
     assert_usage(parser, expected_usage)
 
 
-@pytest.mark.parametrize("name_mapping_policy,expected_usage", [
-    (NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT, "usage: test [-h] [-a ALPHA] [-b BETA]\n"),
-    (NameMappingPolicy.BY_NAME_IF_KWONLY, "usage: test [-h] [-b BETA] [alpha]\n"),
-])
-def test_varargs_between_positional_and_kwonly__with_defaults(name_mapping_policy, expected_usage) -> None:
-
+@pytest.mark.parametrize(
+    "name_mapping_policy,expected_usage",
+    [
+        (
+            NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT,
+            "usage: test [-h] [-a ALPHA] [-b BETA]\n",
+        ),
+        (NameMappingPolicy.BY_NAME_IF_KWONLY, "usage: test [-h] [-b BETA] [alpha]\n"),
+    ],
+)
+def test_varargs_between_positional_and_kwonly__with_defaults(
+    name_mapping_policy, expected_usage
+) -> None:
     def func(alpha: int = 1, *, beta: int = 2) -> str:
         return f"{alpha}, {beta}"
 
@@ -89,20 +108,29 @@ def test_varargs_between_positional_and_kwonly__with_defaults(name_mapping_polic
 
 
 def test_kwargs() -> None:
-
     def func(**kwargs) -> str:
         return f"{kwargs}"
 
-    parser = _make_parser_for_function(func, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_KWONLY)
+    parser = _make_parser_for_function(
+        func, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_KWONLY
+    )
     assert_usage(parser, "usage: test [-h]\n")
 
 
-@pytest.mark.parametrize("name_mapping_policy,expected_usage", [
-    (NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT, "usage: test [-h] [-b BETA] [-d DELTA] alpha gamma\n"),
-    (NameMappingPolicy.BY_NAME_IF_KWONLY, "usage: test [-h] -g GAMMA [-d DELTA] alpha [beta]\n"),
-])
+@pytest.mark.parametrize(
+    "name_mapping_policy,expected_usage",
+    [
+        (
+            NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT,
+            "usage: test [-h] [-b BETA] [-d DELTA] alpha gamma\n",
+        ),
+        (
+            NameMappingPolicy.BY_NAME_IF_KWONLY,
+            "usage: test [-h] -g GAMMA [-d DELTA] alpha [beta]\n",
+        ),
+    ],
+)
 def test_all_types_mixed_no_named_varargs(name_mapping_policy, expected_usage) -> None:
-
     def func(alpha: str, beta: int = 1, *, gamma: str, delta: int = 2) -> str:
         return f"{alpha}, {beta}, {gamma}, {delta}"
 
@@ -111,7 +139,8 @@ def test_all_types_mixed_no_named_varargs(name_mapping_policy, expected_usage) -
 
 
 def _make_parser_for_function(
-    func: Callable, name_mapping_policy: str = NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+    func: Callable,
+    name_mapping_policy: NameMappingPolicy = NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT,
 ) -> ArgumentParser:
     parser = ArgumentParser(prog="test")
     parser_add_argument_specs = infer_argspecs_from_function(
@@ -120,7 +149,7 @@ def _make_parser_for_function(
     for parser_add_argument_spec in parser_add_argument_specs:
         parser.add_argument(
             *parser_add_argument_spec.cli_arg_names,
-            **parser_add_argument_spec.get_all_kwargs()
+            **parser_add_argument_spec.get_all_kwargs(),
         )
     return parser
 
@@ -128,6 +157,9 @@ def _make_parser_for_function(
 def assert_usage(parser: ArgumentParser, expected_usage: str) -> None:
     assert expected_usage == parser.format_usage()
 
-def assert_parsed(parser: ArgumentParser, argv: list[str], expected_result: Namespace) -> None:
+
+def assert_parsed(
+    parser: ArgumentParser, argv: list[str], expected_result: Namespace
+) -> None:
     parsed = parser.parse_args(argv)
     assert parsed == expected_result

--- a/tests/test_mapping_policies.py
+++ b/tests/test_mapping_policies.py
@@ -1,3 +1,4 @@
+import sys
 from argparse import ArgumentParser, Namespace
 from typing import Callable, List
 
@@ -67,7 +68,11 @@ def test_varargs(name_mapping_policy) -> None:
         return f"{file_paths}"
 
     parser = _make_parser_for_function(func, name_mapping_policy=name_mapping_policy)
-    assert_usage(parser, "usage: test [-h] [file-paths ...]\n")
+    expected_usage = "usage: test [-h] [file-paths ...]\n"
+    if sys.version_info < (3, 9):
+        # https://github.com/python/cpython/issues/82619
+        expected_usage = "usage: test [-h] [file-paths [file-paths ...]]\n"
+    assert_usage(parser, expected_usage)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -5,6 +5,7 @@ Regression tests
 import pytest
 
 import argh
+from argh.assembling import NameMappingPolicy
 
 from .base import DebugArghParser, run
 
@@ -20,7 +21,9 @@ def test_regression_issue12():
         yield f"foo {foo}, fox {fox}"
 
     parser = DebugArghParser()
-    parser.set_default_command(cmd)
+    parser.set_default_command(
+        cmd, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+    )
 
     assert run(parser, "").out == "foo 1, fox 2\n"
     assert run(parser, "--foo 3").out == "foo 3, fox 2\n"
@@ -40,12 +43,16 @@ def test_regression_issue12_help_flag():
 
     # no help → no conflict
     parser = DebugArghParser("PROG", add_help=False)
-    parser.set_default_command(ddos)
+    parser.set_default_command(
+        ddos, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+    )
     assert run(parser, "-h 127.0.0.1").out == "so be it, 127.0.0.1!\n"
 
     # help added → conflict → short name ignored
     parser = DebugArghParser("PROG", add_help=True)
-    parser.set_default_command(ddos)
+    parser.set_default_command(
+        ddos, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+    )
     assert run(parser, "-h 127.0.0.1", exit=True) == 0
 
 
@@ -68,7 +75,9 @@ def test_regression_issue27():
             return "{0!r} is right out".format(count)
 
     parser = DebugArghParser()
-    parser.add_commands([parrot, grenade])
+    parser.add_commands(
+        [parrot, grenade], name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+    )
 
     # default → type (int)
     assert run(parser, "grenade").out == (
@@ -147,6 +156,8 @@ def test_regression_issue104():
         )
 
     parser = DebugArghParser()
-    parser.set_default_command(cmd)
+    parser.set_default_command(
+        cmd, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_HAS_DEFAULT
+    )
     expected = "abc\ndef\n8\n9\n{}\n"
     assert run(parser, "abc def --baz-baz 8").out == expected

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist =
     pypy3
     as-module
     lint
+    docs
 skipdist = true
 isolated_build = true
 skip_missing_interpreters = true


### PR DESCRIPTION
The original workflow of func-args-to-CLI-args inferring has been split into policies from which the user can choose.

The default policy, `BY_NAME_IF_HAS_DEFAULT`, closely follows the pre-v.0.30 behaviour (although there's a minor breaking change).

The new and recommended policy, `BY_NAME_IF_KWONLY`, enables for finer control over the resulting required vs. optional and positional vs. named arguments.