### PR TITLE
Strip trailing underscore from option names

### DIFF
--- a/src/argh/assembling.py
+++ b/src/argh/assembling.py
@@ -153,6 +153,9 @@ def infer_argspecs_from_function(
     )
 
     def _make_cli_arg_names_options(arg_name) -> Tuple[List[str], List[str]]:
+        # str.removesuffix() can be used here starting with Python 3.9
+        if arg_name.endswith("_"):
+            arg_name = arg_name[:-1]
         cliified_arg_name = arg_name.replace("_", "-")
         positionals = [cliified_arg_name]
         can_have_short_opt = arg_name[0] not in conflicting_opts

--- a/tests/test_assembling.py
+++ b/tests/test_assembling.py
@@ -669,7 +669,6 @@ def test_kwonlyargs__policy_modern():
     ]
 
 
-@pytest.mark.xfail()
 def test_trailing_underscore_in_argument_name():
     "Stripping trailing underscores from named options"
 

--- a/tests/test_assembling.py
+++ b/tests/test_assembling.py
@@ -669,6 +669,25 @@ def test_kwonlyargs__policy_modern():
     ]
 
 
+@pytest.mark.xfail()
+def test_trailing_underscore_in_argument_name():
+    "Stripping trailing underscores from named options"
+
+    def cmd(*, foo_="foo", bar_):
+        return (foo_, bar_)
+
+    parser = argh.ArghParser()
+    parser.add_argument = MagicMock()
+    parser.set_default_command(
+        cmd, name_mapping_policy=NameMappingPolicy.BY_NAME_IF_KWONLY
+    )
+    help_tmpl = argh.constants.DEFAULT_ARGUMENT_TEMPLATE
+    assert parser.add_argument.mock_calls == [
+        call("-f", "--foo", default="foo", type=str, help=help_tmpl),
+        call("-b", "--bar", required=True, help=help_tmpl),
+    ]
+
+
 @patch("argh.assembling.COMPLETION_ENABLED", True)
 def test_custom_argument_completer():
     "Issue #33: Enable custom per-argument shell completion"


### PR DESCRIPTION
Removes a trailing underscore from function argument names when inferring option names, to avoid name clashes with reserved words and builtins (e.g. `--class` or `--all`).  Implements #222.