### PR TITLE
Fix type annotation of `errors` in `wrap_errors`

### DIFF
--- a/src/argh/decorators.py
+++ b/src/argh/decorators.py
@@ -11,7 +11,7 @@
 Command decorators
 ~~~~~~~~~~~~~~~~~~
 """
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Type
 
 from argh.constants import (
     ATTR_ALIASES,
@@ -161,7 +161,7 @@ def arg(*args: str, **kwargs) -> Callable:
 
 
 def wrap_errors(
-    errors: Optional[List[Exception]] = None,
+    errors: Optional[List[Type[Exception]]] = None,
     processor: Optional[Callable] = None,
     *args,
 ) -> Callable:


### PR DESCRIPTION
original typing is `List[Exception]`, which is **not** the **type of Exception** class such as `[AssertionError]`. 
should be fixed as `List[Type[Exception]]`.