### PR TITLE
Fix type hint for alias decorator

### DIFF
--- a/src/argh/decorators.py
+++ b/src/argh/decorators.py
@@ -52,7 +52,7 @@ def named(new_name: str) -> Callable:
     return wrapper
 
 
-def aliases(*names: List[str]) -> Callable:
+def aliases(*names: str) -> Callable:
     """
     Defines alternative command name(s) for given function (along with its
     original name). Usage::


### PR DESCRIPTION
Basically, the annotation for a stared argument should be the elements of the list, not the list.